### PR TITLE
Feature allocated memory

### DIFF
--- a/index.php
+++ b/index.php
@@ -183,8 +183,8 @@ if( isset($_SESSION['USER']) ){
                 $templateBuilder->setParam("OWNER", $data["nodes"][0]["owner"]);
                 $templateBuilder->setParam("TRES", $data["nodes"][0]["tres"]);
                 $templateBuilder->setParam("TRES_USED", $data["nodes"][0]["tres_used"]);
-                $templateBuilder->setParam("BOOT_TIME", \utils\get_date_from_unix($data["nodes"][0], "boot_time"));
-                $templateBuilder->setParam("LAST_BUSY", \utils\get_date_from_unix($data["nodes"][0], "last_busy"));
+                $templateBuilder->setParam("BOOT_TIME", \utils\get_date_from_unix_if_defined($data["nodes"][0], "boot_time"));
+                $templateBuilder->setParam("LAST_BUSY", \utils\get_date_from_unix_if_defined($data["nodes"][0], "last_busy"));
                 $templateBuilder->setParam("PARTITIONS", count($data["nodes"][0]["partitions"]) > 0 ? '<li><span class="monospaced">' . implode('</li><li><span class="monospaced">', $data["nodes"][0]["partitions"]) . '</span></li>' : '');
                 $templateBuilder->setParam("RESERVATION", $data["nodes"][0]["reservation"] ?? '');
                 $templateBuilder->setParam("SLURM_VERSION", $data["nodes"][0]["version"] ?? '');

--- a/index.php
+++ b/index.php
@@ -121,6 +121,8 @@ if( isset($_SESSION['USER']) ){
                 $templateBuilder->setParam("MEM_PERCENTAGE", ($data["nodes"][0]["real_memory"]-$data["nodes"][0]["free_mem"]["number"])/$data["nodes"][0]["real_memory"]*100);
                 $templateBuilder->setParam("MEM_USED", $data["nodes"][0]["real_memory"] - $data["nodes"][0]["free_mem"]["number"]);
                 $templateBuilder->setParam("MEM_TOTAL", $data["nodes"][0]["real_memory"]);
+                $templateBuilder->setParam("ALLOC_MEM_PERCENTAGE", ($data["nodes"][0]["real_memory"]-$data["nodes"][0]["alloc_memory"])/$data["nodes"][0]["real_memory"]*100);
+                $templateBuilder->setParam("ALLOC_MEM", $data["nodes"][0]["real_memory"] - $data["nodes"][0]["alloc_memory"]);
 
                 $gres = $data["nodes"][0]["gres"];
                 $gres_used = $data["nodes"][0]["gres_used"];
@@ -181,6 +183,11 @@ if( isset($_SESSION['USER']) ){
                 $templateBuilder->setParam("OWNER", $data["nodes"][0]["owner"]);
                 $templateBuilder->setParam("TRES", $data["nodes"][0]["tres"]);
                 $templateBuilder->setParam("TRES_USED", $data["nodes"][0]["tres_used"]);
+                $templateBuilder->setParam("BOOT_TIME", \utils\get_date_from_unix($data["nodes"][0], "boot_time"));
+                $templateBuilder->setParam("LAST_BUSY", \utils\get_date_from_unix($data["nodes"][0], "last_busy"));
+                $templateBuilder->setParam("PARTITIONS", count($data["nodes"][0]["partitions"]) > 0 ? '<li><span class="monospaced">' . implode('</li><li><span class="monospaced">', $data["nodes"][0]["partitions"]) . '</span></li>' : '');
+                $templateBuilder->setParam("RESERVATION", $data["nodes"][0]["reservation"] ?? '');
+                $templateBuilder->setParam("SLURM_VERSION", $data["nodes"][0]["version"] ?? '');
 
                 $contents .= $templateBuilder->build();
             }

--- a/index.php
+++ b/index.php
@@ -121,8 +121,8 @@ if( isset($_SESSION['USER']) ){
                 $templateBuilder->setParam("MEM_PERCENTAGE", ($data["nodes"][0]["real_memory"]-$data["nodes"][0]["free_mem"]["number"])/$data["nodes"][0]["real_memory"]*100);
                 $templateBuilder->setParam("MEM_USED", $data["nodes"][0]["real_memory"] - $data["nodes"][0]["free_mem"]["number"]);
                 $templateBuilder->setParam("MEM_TOTAL", $data["nodes"][0]["real_memory"]);
-                $templateBuilder->setParam("ALLOC_MEM_PERCENTAGE", ($data["nodes"][0]["real_memory"]-$data["nodes"][0]["alloc_memory"])/$data["nodes"][0]["real_memory"]*100);
-                $templateBuilder->setParam("ALLOC_MEM", $data["nodes"][0]["real_memory"] - $data["nodes"][0]["alloc_memory"]);
+                $templateBuilder->setParam("ALLOC_MEM_PERCENTAGE", ($data["nodes"][0]["alloc_memory"])/$data["nodes"][0]["real_memory"]*100);
+                $templateBuilder->setParam("ALLOC_MEM", $data["nodes"][0]["alloc_memory"]);
 
                 $gres = $data["nodes"][0]["gres"];
                 $gres_used = $data["nodes"][0]["gres_used"];

--- a/templates/nodeinfo.html
+++ b/templates/nodeinfo.html
@@ -22,7 +22,7 @@
         </tr>
 
         <tr title="The sum of all RAM memory currently used on that node. This includes buffer and cache memory, which is currently in use but available.">
-            <td>Memory (RAM inc. buf/cache):</td>
+            <td>Memory:</td>
             <td>
                 <div class="progress">
                     <div class="progress-bar"
@@ -33,7 +33,7 @@
             </td>
         </tr>
         <tr title="Sum of RAM used by SLURM jobs. Does not include memory used by other processes or the kernel.">
-            <td>RAM used by jobs:</td>
+            <td>RAM of jobs:</td>
             <td>
                 <div class="progress">
                     <div class="progress-bar"

--- a/templates/nodeinfo.html
+++ b/templates/nodeinfo.html
@@ -20,8 +20,9 @@
                 {{CPU_USED}} of {{CPU_TOTAL}} CPUs in use ({{CPU_PERCENTAGE}} %)
             </td>
         </tr>
-        <tr>
-            <td>Memory:</td>
+
+        <tr title="The sum of all RAM memory currently used on that node. This includes buffer and cache memory, which is currently in use but available.">
+            <td>Memory (RAM inc. buf/cache):</td>
             <td>
                 <div class="progress">
                     <div class="progress-bar"
@@ -31,6 +32,18 @@
                 {{MEM_USED}} of {{MEM_TOTAL}} MiB RAM in use ({{MEM_PERCENTAGE}} %)
             </td>
         </tr>
+        <tr title="Sum of RAM used by SLURM jobs. Does not include memory used by other processes or the kernel.">
+            <td>RAM used by jobs:</td>
+            <td>
+                <div class="progress">
+                    <div class="progress-bar"
+                         role="progressbar"
+                         style="width: {{ALLOC_MEM_PERCENTAGE}}%" aria-valuenow="{{ALLOC_MEM}}" aria-valuemin="0" aria-valuemax="{{MEM_TOTAL}}"></div><br>
+                </div>
+                {{ALLOC_MEM}} of {{MEM_TOTAL}} MiB RAM in use ({{ALLOC_MEM_PERCENTAGE}} %)
+            </td>
+        </tr>
+
         <tr>
             <td>GPUs:</td>
             <td>
@@ -93,6 +106,30 @@
                 <tr>
                     <td>TRES used:</td>
                     <td><span class="feature">{{TRES_USED}}</span></td>
+                </tr>
+                <tr>
+                    <td>Partitions:</td>
+                    <td>
+                        <ul>
+                            {{PARTITIONS}}
+                        </ul>
+                    </td>
+                </tr>
+                <tr>
+                    <td>Boot time:</td>
+                    <td>{{BOOT_TIME}}</td>
+                </tr>
+                <tr>
+                    <td>Last busy:</td>
+                    <td>{{LAST_BUSY}}</td>
+                </tr>
+                <tr>
+                    <td>Reservation:</td>
+                    <td>{{RESERVATION}}</td>
+                </tr>
+                <tr>
+                    <td>SLURM version:</td>
+                    <td>{{SLURM_VERSION}}</td>
                 </tr>
             </table>
         </div>


### PR DESCRIPTION
`free_mem` does not include buffer and cache memory (and hence there is more memory available than shown). Hence, I have added `available_mem` as an additional field on the node info page.

Additionally, following fields were added to the node info page:
- partitions list
- boot and last busy time
- reservation name (if there is a reservation)
- SLURM version of the node