### PR TITLE
Feature exclude p low

### DIFF
--- a/client.inc.php
+++ b/client.inc.php
@@ -72,10 +72,19 @@ class Client {
         return array_column($json['nodes'], 'name');
     }
 
-    function get_jobs() : array {
+    function get_jobs(?array $filter = NULL) : array {
         # curl --unix-socket /run/slurmrestd/slurmrestd.socket http://slurm/slurm/v0.0.39/jobs
         $request = new Request();
         $json = $request->request_json("jobs");
+
+        if($filter != NULL){
+            if(isset($filter['exclude_p_low'])){
+                $jobs_array = $this->_feature_exclude_p_low($json['jobs']);
+                $json['jobs'] = $jobs_array;
+            }
+
+        }
+
         return $json;
     }
 
@@ -205,11 +214,25 @@ class Client {
      * request but we filter the response.
      * See https://github.com/nikolaussuess/slurm-dashboard/issues/12
      */
-    private function _issue12_bugfix_post_request_filtering($array, $value){
+    private function _issue12_bugfix_post_request_filtering(array $array, string $value){
         return array_filter($array, function ($v, $k) use($value) {
             foreach($v['state']['current'] as $state){
                 if( $state == $value )
                     return TRUE;
+            }
+            return FALSE;
+        }, ARRAY_FILTER_USE_BOTH);
+    }
+
+    /**
+     * Exclude partition p_low in /slurm/jobs queue.
+     * @param array $jobs Job array
+     * @return array Job array without jobs in partition p_low
+     */
+    private function _feature_exclude_p_low(array $jobs) {
+        return array_filter($jobs, function ($v, $k) {
+            if( $v['partition'] != 'p_low' ){
+                return TRUE;
             }
             return FALSE;
         }, ARRAY_FILTER_USE_BOTH);

--- a/client.inc.php
+++ b/client.inc.php
@@ -77,12 +77,12 @@ class Client {
         $request = new Request();
         $json = $request->request_json("jobs");
 
+        // Exclude partition p_low if parameter exclude_p_low=1
         if($filter != NULL){
             if(isset($filter['exclude_p_low']) && $filter['exclude_p_low'] == 1){
                 $jobs_array = $this->_feature_exclude_p_low($json['jobs']);
                 $json['jobs'] = $jobs_array;
             }
-
         }
 
         return $json;

--- a/client.inc.php
+++ b/client.inc.php
@@ -78,7 +78,7 @@ class Client {
         $json = $request->request_json("jobs");
 
         if($filter != NULL){
-            if(isset($filter['exclude_p_low'])){
+            if(isset($filter['exclude_p_low']) && $filter['exclude_p_low'] == 1){
                 $jobs_array = $this->_feature_exclude_p_low($json['jobs']);
                 $json['jobs'] = $jobs_array;
             }

--- a/index.php
+++ b/index.php
@@ -381,6 +381,24 @@ if( isset($_SESSION['USER']) ){
             $contents .= "<h2>Jobs</h2>";
 
             $contents .= <<<EOF
+<div class="form-check form-switch">
+  <input 
+        class="form-check-input" 
+        type="checkbox" 
+        role="switch" 
+        id="show_p_low" 
+        onclick="if( this.checked() ) window.location.href = '?action=jobs&exclude_p_low=1'; else window.location.href = '?action=jobs';"
+        >
+  <label 
+        class="form-check-label" 
+        for="show_p_low">
+            Show partition <span class="monospaced">p_low</span>
+  </label>
+</div>
+EOF;
+
+
+            $contents .= <<<EOF
 <div class="table-responsive">
     <table class="tableFixHead table">
         <thead>

--- a/index.php
+++ b/index.php
@@ -396,7 +396,7 @@ $contents .= <<<EOF
   <label 
         class="form-check-label" 
         for="show_p_low">
-            Hide partition <span title="Every user can use partition p_low. The aim of the partition p_low is to use any (currently) unused resources for experiments that should finish at some point, but it does not matter when. Any normal job will have higher priority than a job in p_low and will hence interrupt (REQUEUE) these jobs."><span class="monospaced">p_low</span> &#xF431;</span>
+            Hide partition <span title="Every user can use partition p_low. The aim of the partition p_low is to use any (currently) unused resources for experiments that should finish at some point, but it does not matter when. Any normal job will have higher priority than a job in p_low and will hence interrupt (REQUEUE) these jobs."><span class="monospaced">p_low</span> <span class="glyphicon glyphicon-info-sign"></span></span>
   </label>
 </div>
 EOF;

--- a/index.php
+++ b/index.php
@@ -387,7 +387,11 @@ if( isset($_SESSION['USER']) ){
         type="checkbox" 
         role="switch" 
         id="show_p_low" 
-        onclick="if( this.checked() ) window.location.href = '?action=jobs&exclude_p_low=1'; else window.location.href = '?action=jobs';"
+        onclick="if( this.checked ) window.location.href = '?action=jobs&exclude_p_low=1'; else window.location.href = '?action=jobs';"
+EOF;
+            if(isset($_GET['exclude_p_low']) && $_GET['exclude_p_low'] == 1)
+                $contents .= ' checked ';
+$contents .= <<<EOF
         >
   <label 
         class="form-check-label" 
@@ -417,6 +421,11 @@ EOF;
         </thead>
         <tbody>
 EOF;
+
+            $filter = array();
+            if(isset($_GET['exclude_p_low']) && $_GET['exclude_p_low'] == 1)
+                $filter['exclude_p_low'] = 1;
+
             $jobs = $dao->get_jobs();
             foreach( $jobs['jobs'] as $job ) {
 

--- a/index.php
+++ b/index.php
@@ -426,7 +426,7 @@ EOF;
             if(isset($_GET['exclude_p_low']) && $_GET['exclude_p_low'] == 1)
                 $filter['exclude_p_low'] = 1;
 
-            $jobs = $dao->get_jobs();
+            $jobs = $dao->get_jobs($filter);
             foreach( $jobs['jobs'] as $job ) {
 
                 $contents .= "<tr>";

--- a/index.php
+++ b/index.php
@@ -380,6 +380,14 @@ if( isset($_SESSION['USER']) ){
         case "jobs":
             $contents .= "<h2>Jobs</h2>";
 
+            // Allow to exclude jobs of partition p_low
+            // Every user can use partition p_low. The aim of the partition p_low is to use
+            // any (currently) unused resources for experiments that should finish at some point,
+            // but it does not matter when. Any normal job will have higher priority than a job in
+            // p_low and will hence interrupt (REQUEUE) these jobs.
+            //
+            // The filtering is done locally on the web server.
+            // JavaScript is required.
             $contents .= <<<EOF
 <div class="form-check form-switch">
   <input 
@@ -422,6 +430,8 @@ EOF;
         <tbody>
 EOF;
 
+            // Filter
+            // Exclude partition p_low if parameter exclude_p_low=1
             $filter = array();
             if(isset($_GET['exclude_p_low']) && $_GET['exclude_p_low'] == 1)
                 $filter['exclude_p_low'] = 1;

--- a/index.php
+++ b/index.php
@@ -396,7 +396,7 @@ $contents .= <<<EOF
   <label 
         class="form-check-label" 
         for="show_p_low">
-            Hide partition <span class="monospaced" title="Every user can use partition p_low. The aim of the partition p_low is to use any (currently) unused resources for experiments that should finish at some point, but it does not matter when. Any normal job will have higher priority than a job in p_low and will hence interrupt (REQUEUE) these jobs.">p_low</span>
+            Hide partition <span title="Every user can use partition p_low. The aim of the partition p_low is to use any (currently) unused resources for experiments that should finish at some point, but it does not matter when. Any normal job will have higher priority than a job in p_low and will hence interrupt (REQUEUE) these jobs."><span class="monospaced">p_low</span> &#xF431;</span>
   </label>
 </div>
 EOF;

--- a/index.php
+++ b/index.php
@@ -396,7 +396,7 @@ $contents .= <<<EOF
   <label 
         class="form-check-label" 
         for="show_p_low">
-            Hide partition <span title="Every user can use partition p_low. The aim of the partition p_low is to use any (currently) unused resources for experiments that should finish at some point, but it does not matter when. Any normal job will have higher priority than a job in p_low and will hence interrupt (REQUEUE) these jobs."><span class="monospaced">p_low</span> <span class="glyphicon glyphicon-info-sign"></span></span>
+            Hide partition <span title="Every user can use partition p_low. The aim of the partition p_low is to use any (currently) unused resources for experiments that should finish at some point, but it does not matter when. Any normal job will have higher priority than a job in p_low and will hence interrupt (REQUEUE) these jobs."><span class="monospaced">p_low</span></span>
   </label>
 </div>
 EOF;

--- a/index.php
+++ b/index.php
@@ -396,7 +396,7 @@ $contents .= <<<EOF
   <label 
         class="form-check-label" 
         for="show_p_low">
-            Show partition <span class="monospaced">p_low</span>
+            Hide partition <span class="monospaced" title="Every user can use partition p_low. The aim of the partition p_low is to use any (currently) unused resources for experiments that should finish at some point, but it does not matter when. Any normal job will have higher priority than a job in p_low and will hence interrupt (REQUEUE) these jobs.">p_low</span>
   </label>
 </div>
 EOF;


### PR DESCRIPTION
On our cluster, we have a partition called `p_low`. This partition has the lowest `PriorityTier`.

Every user can use partition `p_low`. The aim of this partition is to use any (currently) unused resources for experiments that should finish at some point, but it does not matter when. Any normal job will have higher priority than a job in `p_low` and will hence interrupt (`REQUEUE`) these jobs.

p_low is this well-suited for e.g.
- long-running jobs that periodically save their state and can continue from there, and that should be able to use as many resources as possible. It is, however, usually not a good idea to use this partition for "normal" jobs that should finish as soon as possible.
- experiments that consist of many (hundreds or thousands) of (smaller) steps or tasks that can run in parallel.

Since `/slurm/jobs` does not support any filtering but `p_low` may contain a lot of jobs, we provide an option to exclude them.