### PR TITLE
Feature job count

### DIFF
--- a/client.inc.php
+++ b/client.inc.php
@@ -139,7 +139,7 @@ class Client {
          * Issue 12 specific code
          * See https://github.com/nikolaussuess/slurm-dashboard/issues/12
          */
-        // Running works on server side
+        // RUNNING works on server side
         // COMPLETED does not
         if(isset($filter['state']) && $filter['state'] == 'COMPLETED'){
             $jobs_array = $this->_issue12_bugfix_post_request_filtering($json['jobs'], 'COMPLETED');

--- a/client.inc.php
+++ b/client.inc.php
@@ -117,7 +117,12 @@ class Client {
                  * Issue 12 specific code
                  * See https://github.com/nikolaussuess/slurm-dashboard/issues/12
                  */
-                if($filter['state'] != 'COMPLETED'){
+                if(
+                    $filter['state'] != 'COMPLETED' &&
+                    $filter['state'] != 'FAILED' &&
+                    $filter['state'] != 'TIMEOUT' &&
+                    $filter['state'] != 'OUT_OF_MEMORY'
+                ){
                     $query_string .= '&state=' . $filter['state'];
                 }
                 // ORIGINAL CODE:
@@ -134,8 +139,23 @@ class Client {
          * Issue 12 specific code
          * See https://github.com/nikolaussuess/slurm-dashboard/issues/12
          */
+        // Running works on server side
+        // COMPLETED does not
         if(isset($filter['state']) && $filter['state'] == 'COMPLETED'){
             $jobs_array = $this->_issue12_bugfix_post_request_filtering($json['jobs'], 'COMPLETED');
+            $json['jobs'] = $jobs_array;
+        }
+        // FAILED does not
+        elseif(isset($filter['state']) && $filter['state'] == 'FAILED'){
+            $jobs_array = $this->_issue12_bugfix_post_request_filtering($json['jobs'], 'FAILED');
+            $json['jobs'] = $jobs_array;
+        }
+        elseif(isset($filter['state']) && $filter['state'] == 'TIMEOUT'){
+            $jobs_array = $this->_issue12_bugfix_post_request_filtering($json['jobs'], 'TIMEOUT');
+            $json['jobs'] = $jobs_array;
+        }
+        elseif(isset($filter['state']) && $filter['state'] == 'OUT_OF_MEMORY'){
+            $jobs_array = $this->_issue12_bugfix_post_request_filtering($json['jobs'], 'OUT_OF_MEMORY');
             $json['jobs'] = $jobs_array;
         }
         // END Issue 12

--- a/index.php
+++ b/index.php
@@ -409,6 +409,15 @@ $contents .= <<<EOF
 </div>
 EOF;
 
+            // Filter
+            // Exclude partition p_low if parameter exclude_p_low=1
+            $filter = array();
+            if(isset($_GET['exclude_p_low']) && $_GET['exclude_p_low'] == 1)
+                $filter['exclude_p_low'] = 1;
+
+            $jobs = $dao->get_jobs($filter);
+
+            $contents .= '<div>Found <span style="font-weight: bold">' . count($jobs['jobs']) . ' jobs</span>.</div>';
 
             $contents .= <<<EOF
 <div class="table-responsive">
@@ -430,13 +439,6 @@ EOF;
         <tbody>
 EOF;
 
-            // Filter
-            // Exclude partition p_low if parameter exclude_p_low=1
-            $filter = array();
-            if(isset($_GET['exclude_p_low']) && $_GET['exclude_p_low'] == 1)
-                $filter['exclude_p_low'] = 1;
-
-            $jobs = $dao->get_jobs($filter);
             foreach( $jobs['jobs'] as $job ) {
 
                 $contents .= "<tr>";
@@ -602,6 +604,11 @@ EOF;
             $templateBuilder->setParam("TIME_MAX_VALUE", $filter['end_time_value'] ?? '');
             $contents .= $templateBuilder->build();
 
+            $jobs = $dao->get_jobs_from_slurmdb($filter);
+            $jobs = array_reverse($jobs['jobs']); // newest entry first
+
+            $contents .= '<div>Found <span style="font-weight: bold">' . count($jobs) . ' jobs</span>.</div>';
+
             $contents .= <<<EOF
 <div class="table-responsive">
     <table class="tableFixHead table">
@@ -622,8 +629,7 @@ EOF;
         </thead>
         <tbody>
 EOF;
-            $jobs = $dao->get_jobs_from_slurmdb($filter);
-            $jobs = array_reverse($jobs['jobs']); // newest entry first
+
             foreach( $jobs as $job ) {
 
                 $contents .= "<tr>";


### PR DESCRIPTION
- Extension for pull request #13 so that filtering for `FAILED`, `TIMEOUT` and `OUT_OF_MEMORY` works, too. See also #12.
- Display the job count.