### PR TITLE
Bugfix gres parsing

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -3,6 +3,10 @@ This is a small dashboard that displays some information about a slurm cluster. 
 
 ![Resource overview](./imgs/resources.png?raw=true "Resource overview")
 
+Currently tested with the following Slurm versions:
+- 23.11.x
+- 24.05.x
+
 ## Current features
 - display cluster usage information (state, CPUs, memory, gpus per node)
 - display the current job queue, including a job detail page
@@ -10,7 +14,7 @@ This is a small dashboard that displays some information about a slurm cluster. 
 - communication with `slurmrestd` via unix socket
 - caching of the `slurmrestd` responses (using APCu)
 - display and filter job history (from `slurmdbd`)
-- display list of users with their respective accounts (for administrators only)
+- display list of users with their respective accounts (for administrators and privileged users only)
 - show planned maintenances (`flags=maint`) that were created with e.g. `scontrol create reservation starttime=2024-11-02T13:30:00 duration=5 user=root flags=maint nodes=mynode`
 
 ![Job queue](./imgs/queue.png?raw=true "Job queue")
@@ -18,6 +22,7 @@ This is a small dashboard that displays some information about a slurm cluster. 
 ![Job history](./imgs/job_history.png?raw=true "Job history")
 
 ### Planned features
+- Authentication (at `slurmrestd`) via JWT.
 - Allow administrators to requeue / cancel / ... jobs.
 - Allow users to requeue and cancel their own jobs.
 - Allow users to submit jobs via a web interface.

--- a/index.php
+++ b/index.php
@@ -132,11 +132,14 @@ if( isset($_SESSION['USER']) ){
                     $gpus_percentage = 0;
                 }
                 else {
+
                     $gpus = preg_replace('/:(\d+)\(.*\)$/', '$1', $gres);
                     $gpus_used = preg_replace('/:(\d+)\(.*\)$/', '$1', $gres_used);
                     #$gpus = preg_replace('/.*gpu:(\d+).*|.*gpu:\(null\):(\d+).*/', '$1$2', $gres);
                     #$gpus_used = preg_replace('/.*gpu:(\d+).*|.*gpu:\(null\):(\d+).*/', '$1$2', $gres_used);
-                    $gpus_percentage = (int)$gpus_used / (int)$gpus * 100;
+                    echo "GPUs='$gpus', gpus_used='$gpus_used";
+                    #$gpus_percentage = (int)$gpus_used / (int)$gpus * 100;
+                    $gpus_percentage = 1;
                 }
                 $templateBuilder->setParam("GPU_PERCENTAGE", $gpus_percentage);
                 $templateBuilder->setParam("GPU_USED", $gpus_used);

--- a/index.php
+++ b/index.php
@@ -133,11 +133,11 @@ if( isset($_SESSION['USER']) ){
                 }
                 else {
 
-                    $gpus = preg_replace('/.*:(\d+)\(.*\)$/', '$2', $gres);
-                    $gpus_used = preg_replace('/.*:(\d+)\(.*\)$/', '$2', $gres_used);
+                    $gpus = preg_replace('/:(\d+)\(.*\)$/', '$2', $gres);
+                    $gpus_used = preg_replace('/:(\d+)\(.*\)$/', '$2', $gres_used);
                     #$gpus = preg_replace('/.*gpu:(\d+).*|.*gpu:\(null\):(\d+).*/', '$1$2', $gres);
                     #$gpus_used = preg_replace('/.*gpu:(\d+).*|.*gpu:\(null\):(\d+).*/', '$1$2', $gres_used);
-                    echo "GPUs='$gpus', gpus_used='$gpus_used";
+                    echo "GPUs='$gpus', gpus_used='$gpus_used', gres='$gres'";
                     #$gpus_percentage = (int)$gpus_used / (int)$gpus * 100;
                     $gpus_percentage = 1;
                 }

--- a/index.php
+++ b/index.php
@@ -135,10 +135,10 @@ if( isset($_SESSION['USER']) ){
 
                     $gpus = preg_replace('/.*:(\d+)(?:\(.*\))?$/', '$1', $gres);
                     $gpus_used = preg_replace('/.*:(\d+)(?:\(.*\))?$/', '$1', $gres_used);
-                    #$gpus = preg_replace('/.*gpu:(\d+).*|.*gpu:\(null\):(\d+).*/', '$1$2', $gres);
-                    #$gpus_used = preg_replace('/.*gpu:(\d+).*|.*gpu:\(null\):(\d+).*/', '$1$2', $gres_used);
+                    //$gpus = preg_replace('/.*gpu:(\d+).*|.*gpu:\(null\):(\d+).*/', '$1$2', $gres);
+                    //$gpus_used = preg_replace('/.*gpu:(\d+).*|.*gpu:\(null\):(\d+).*/', '$1$2', $gres_used);
                     // For debugging
-                    echo "GPUs='$gpus', gpus_used='$gpus_used', gres='$gres', gres_used='$gres_used'";
+                    //echo "GPUs='$gpus', gpus_used='$gpus_used', gres='$gres', gres_used='$gres_used'";
                     $gpus_percentage = (int)$gpus_used / (int)$gpus * 100;
                 }
                 $templateBuilder->setParam("GPU_PERCENTAGE", $gpus_percentage);

--- a/index.php
+++ b/index.php
@@ -133,8 +133,8 @@ if( isset($_SESSION['USER']) ){
                 }
                 else {
 
-                    $gpus = preg_replace('/:(\d+)\(.*\)$/', '$2', $gres);
-                    $gpus_used = preg_replace('/:(\d+)\(.*\)$/', '$2', $gres_used);
+                    $gpus = preg_replace('/:(\d+)(?:\(.*\))?$/', '$2', $gres);
+                    $gpus_used = preg_replace('/:(\d+)(?:\(.*\))?$/', '$2', $gres_used);
                     #$gpus = preg_replace('/.*gpu:(\d+).*|.*gpu:\(null\):(\d+).*/', '$1$2', $gres);
                     #$gpus_used = preg_replace('/.*gpu:(\d+).*|.*gpu:\(null\):(\d+).*/', '$1$2', $gres_used);
                     echo "GPUs='$gpus', gpus_used='$gpus_used', gres='$gres', gres_used='$gres_used'";

--- a/index.php
+++ b/index.php
@@ -133,8 +133,8 @@ if( isset($_SESSION['USER']) ){
                 }
                 else {
 
-                    $gpus = preg_replace('/:(\d+)\(.*\)$/', '$2', $gres);
-                    $gpus_used = preg_replace('/:(\d+)\(.*\)$/', '$2', $gres_used);
+                    $gpus = preg_replace('/.*:(\d+)\(.*\)$/', '$2', $gres);
+                    $gpus_used = preg_replace('/.*:(\d+)\(.*\)$/', '$2', $gres_used);
                     #$gpus = preg_replace('/.*gpu:(\d+).*|.*gpu:\(null\):(\d+).*/', '$1$2', $gres);
                     #$gpus_used = preg_replace('/.*gpu:(\d+).*|.*gpu:\(null\):(\d+).*/', '$1$2', $gres_used);
                     echo "GPUs='$gpus', gpus_used='$gpus_used";

--- a/index.php
+++ b/index.php
@@ -138,7 +138,7 @@ if( isset($_SESSION['USER']) ){
                     #$gpus = preg_replace('/.*gpu:(\d+).*|.*gpu:\(null\):(\d+).*/', '$1$2', $gres);
                     #$gpus_used = preg_replace('/.*gpu:(\d+).*|.*gpu:\(null\):(\d+).*/', '$1$2', $gres_used);
                     // For debugging
-                    #echo "GPUs='$gpus', gpus_used='$gpus_used', gres='$gres', gres_used='$gres_used'";
+                    echo "GPUs='$gpus', gpus_used='$gpus_used', gres='$gres', gres_used='$gres_used'";
                     $gpus_percentage = (int)$gpus_used / (int)$gpus * 100;
                 }
                 $templateBuilder->setParam("GPU_PERCENTAGE", $gpus_percentage);

--- a/index.php
+++ b/index.php
@@ -133,8 +133,8 @@ if( isset($_SESSION['USER']) ){
                 }
                 else {
 
-                    $gpus = preg_replace('/:(\d+)\(.*\)$/', '$1', $gres);
-                    $gpus_used = preg_replace('/:(\d+)\(.*\)$/', '$1', $gres_used);
+                    $gpus = preg_replace('/:(\d+)\(.*\)$/', '$2', $gres);
+                    $gpus_used = preg_replace('/:(\d+)\(.*\)$/', '$2', $gres_used);
                     #$gpus = preg_replace('/.*gpu:(\d+).*|.*gpu:\(null\):(\d+).*/', '$1$2', $gres);
                     #$gpus_used = preg_replace('/.*gpu:(\d+).*|.*gpu:\(null\):(\d+).*/', '$1$2', $gres_used);
                     echo "GPUs='$gpus', gpus_used='$gpus_used";

--- a/index.php
+++ b/index.php
@@ -137,9 +137,9 @@ if( isset($_SESSION['USER']) ){
                     $gpus_used = preg_replace('/.*:(\d+)(?:\(.*\))?$/', '$1', $gres_used);
                     #$gpus = preg_replace('/.*gpu:(\d+).*|.*gpu:\(null\):(\d+).*/', '$1$2', $gres);
                     #$gpus_used = preg_replace('/.*gpu:(\d+).*|.*gpu:\(null\):(\d+).*/', '$1$2', $gres_used);
-                    echo "GPUs='$gpus', gpus_used='$gpus_used', gres='$gres', gres_used='$gres_used'";
-                    #$gpus_percentage = (int)$gpus_used / (int)$gpus * 100;
-                    $gpus_percentage = 1;
+                    // For debugging
+                    #echo "GPUs='$gpus', gpus_used='$gpus_used', gres='$gres', gres_used='$gres_used'";
+                    $gpus_percentage = (int)$gpus_used / (int)$gpus * 100;
                 }
                 $templateBuilder->setParam("GPU_PERCENTAGE", $gpus_percentage);
                 $templateBuilder->setParam("GPU_USED", $gpus_used);

--- a/index.php
+++ b/index.php
@@ -133,8 +133,8 @@ if( isset($_SESSION['USER']) ){
                 }
                 else {
 
-                    $gpus = preg_replace('/:(\d+)(?:\(.*\))?$/', '$2', $gres);
-                    $gpus_used = preg_replace('/:(\d+)(?:\(.*\))?$/', '$2', $gres_used);
+                    $gpus = preg_replace('/:(\d+)(?:\(.*\))?$/', '$1', $gres);
+                    $gpus_used = preg_replace('/:(\d+)(?:\(.*\))?$/', '$1', $gres_used);
                     #$gpus = preg_replace('/.*gpu:(\d+).*|.*gpu:\(null\):(\d+).*/', '$1$2', $gres);
                     #$gpus_used = preg_replace('/.*gpu:(\d+).*|.*gpu:\(null\):(\d+).*/', '$1$2', $gres_used);
                     echo "GPUs='$gpus', gpus_used='$gpus_used', gres='$gres', gres_used='$gres_used'";

--- a/index.php
+++ b/index.php
@@ -133,8 +133,8 @@ if( isset($_SESSION['USER']) ){
                 }
                 else {
 
-                    $gpus = preg_replace('/:(\d+)(?:\(.*\))?$/', '$1', $gres);
-                    $gpus_used = preg_replace('/:(\d+)(?:\(.*\))?$/', '$1', $gres_used);
+                    $gpus = preg_replace('/.*:(\d+)(?:\(.*\))?$/', '$1', $gres);
+                    $gpus_used = preg_replace('/.*:(\d+)(?:\(.*\))?$/', '$1', $gres_used);
                     #$gpus = preg_replace('/.*gpu:(\d+).*|.*gpu:\(null\):(\d+).*/', '$1$2', $gres);
                     #$gpus_used = preg_replace('/.*gpu:(\d+).*|.*gpu:\(null\):(\d+).*/', '$1$2', $gres_used);
                     echo "GPUs='$gpus', gpus_used='$gpus_used', gres='$gres', gres_used='$gres_used'";

--- a/index.php
+++ b/index.php
@@ -132,8 +132,10 @@ if( isset($_SESSION['USER']) ){
                     $gpus_percentage = 0;
                 }
                 else {
-                    $gpus = preg_replace('/.*gpu:(\d+).*|.*gpu:\(null\):(\d+).*/', '$1$2', $gres);
-                    $gpus_used = preg_replace('/.*gpu:(\d+).*|.*gpu:\(null\):(\d+).*/', '$1$2', $gres_used);
+                    $gpus = preg_replace('/:(\d+)\(.*\)$/', '$1', $gres);
+                    $gpus_used = preg_replace('/:(\d+)\(.*\)$/', '$1', $gres_used);
+                    #$gpus = preg_replace('/.*gpu:(\d+).*|.*gpu:\(null\):(\d+).*/', '$1$2', $gres);
+                    #$gpus_used = preg_replace('/.*gpu:(\d+).*|.*gpu:\(null\):(\d+).*/', '$1$2', $gres_used);
                     $gpus_percentage = (int)$gpus_used / (int)$gpus * 100;
                 }
                 $templateBuilder->setParam("GPU_PERCENTAGE", $gpus_percentage);

--- a/index.php
+++ b/index.php
@@ -137,7 +137,7 @@ if( isset($_SESSION['USER']) ){
                     $gpus_used = preg_replace('/:(\d+)\(.*\)$/', '$2', $gres_used);
                     #$gpus = preg_replace('/.*gpu:(\d+).*|.*gpu:\(null\):(\d+).*/', '$1$2', $gres);
                     #$gpus_used = preg_replace('/.*gpu:(\d+).*|.*gpu:\(null\):(\d+).*/', '$1$2', $gres_used);
-                    echo "GPUs='$gpus', gpus_used='$gpus_used', gres='$gres'";
+                    echo "GPUs='$gpus', gpus_used='$gpus_used', gres='$gres', gres_used='$gres_used'";
                     #$gpus_percentage = (int)$gpus_used / (int)$gpus * 100;
                     $gpus_percentage = 1;
                 }

--- a/templates/job_filter_form.html
+++ b/templates/job_filter_form.html
@@ -93,12 +93,26 @@
                             <option value="OUT_OF_MEMORY">OUT_OF_MEMORY</option>
                             <option value="STOPPED">STOPPED</option>
                             <option value="TIMEOUT">TIMEOUT</option>
+                            <option value="RESV_DEL_HOLD" disabled>RESV_DEL_HOLD</option>
                         </optgroup>
                         <optgroup label="Success states">
                             <option value="COMPLETED">COMPLETED</option>
-                            <option value="CONFIGURING">CONFIGURING</option>
                             <option value="COMPLETING">COMPLETING</option>
+                            <option value="CONFIGURING">CONFIGURING</option>
                             <option value="RUNNING">RUNNING</option>
+                        </optgroup>
+                        <optgroup label="Other states">
+                            <option value="PENDING">PENDING</option>
+                            <option value="PREEMPTED">PREEMPTED</option>
+                            <option value="SUSPENDED">SUSPENDED</option>
+                            <option value="REQUEUED">REQUEUED</option>
+                            <option value="REQUEUE_FED" disabled>REQUEUE_FED</option>
+                            <option value="REQUEUE_HOLD" disabled>REQUEUE_HOLD</option>
+                            <option value="RESIZING" disabled>RESIZING</option>
+                            <option value="REVOKED" disabled>REVOKED</option>
+                            <option value="SIGNALING" disabled>SIGNALING</option>
+                            <option value="SPECIAL_EXIT" disabled>SPECIAL_EXIT</option>
+                            <option value="STAGE_OUT" disabled>STAGE_OUT</option>
                         </optgroup>
                     </select>
                 </div>


### PR DESCRIPTION
The dashboard could not properly parse `gres` strings with a `Type` parameter. This was fixed now.

Additionally, missing states were added to the job filter form.