### PR TITLE
Feature edit job, undrain node and config as environment variables

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -182,7 +182,7 @@ However, any slurm version `>= 23.11.x` should work. If you encounter any issues
 5) Make sure that your apache2 config file is not readable by other users (especially if it contains passwords)!
 ```bash
 chown root:root /etc/apache2/sites-available/slurm-dashboard.conf
-chmod 700 /etc/apache2/sites-available/slurm-dashboard.conf
+chmod 600 /etc/apache2/sites-available/slurm-dashboard.conf
 ```
 6) Optionally (but strongly recommended), enable SSL etc.
 7) Start or restart the services:

--- a/README.MD
+++ b/README.MD
@@ -29,6 +29,8 @@ However, any slurm version `>= 23.11.x` should work. If you encounter any issues
 - Authentication (at `slurmrestd`) via JWT (optional).
 - Allow administrators to requeue / cancel / ... jobs (requires JWT).
 - Allow users to requeue and cancel their own jobs (requires JWT).
+- Allow users to edit their own jobs and allow admins to edit all jobs (requires JWT).
+- Allow administrators to `DRAIN` or undrain nodes (requires JWT).
 
 ![Job queue](./imgs/queue.png?raw=true "Job queue")
 
@@ -72,7 +74,7 @@ However, any slurm version `>= 23.11.x` should work. If you encounter any issues
     User=slurm-dashboard
     Group=slurm-dashboard
     ```
-    - Note that users will not be able to submit or cancel jobs.
+    - Note that users will not be able to submit or cancel jobs (i.e., the dashboard is read-only).
  
   - If you want JWT authentication:
     - Follow the instructions [in the official documentation](https://slurm.schedmd.com/jwt.html). In short:
@@ -125,7 +127,7 @@ However, any slurm version `>= 23.11.x` should work. If you encounter any issues
     WantedBy=multi-user.target
     ```
 
-4) Add correct user to the apache vhost (e.g. `/etc/apache2/sites-enabled/slurm-dashboard.conf`). Also set the environment variables accordingly to configure the dashboard. (Alternatively, you could also edit the `globals.inc.php` file to set them, but this is not recommended anymore.) Make sure that your config file is not readable by other users!
+4) Add correct user to the apache vhost (e.g. `/etc/apache2/sites-enabled/slurm-dashboard.conf`). Also set the environment variables accordingly to configure the dashboard. (Alternatively, you could also edit the `globals.inc.php` file to set them, but this is not recommended anymore.
 ```apacheconf
 <VirtualHost *:80>
     ...
@@ -176,8 +178,13 @@ However, any slurm version `>= 23.11.x` should work. If you encounter any issues
     # SetEnv PRIV_USERS        "user1,user2"
 </VirtualHost>
 ```
-5) Optionally (but strongly recommended), enable SSL etc.
-6) Start or restart the services:
+5) Make sure that your apache2 config file is not readable by other users (especially if it contains passwords)!
+```bash
+chown root:root /etc/apache2/sites-available/slurm-dashboard.conf
+chmod 700 /etc/apache2/sites-available/slurm-dashboard.conf
+```
+6) Optionally (but strongly recommended), enable SSL etc.
+7) Start or restart the services:
 ```
 systemctl enable --now slurmrestd
 systemctl enable --now apache2
@@ -185,7 +192,11 @@ systemctl enable --now apache2
 systemctl restart slurmrestd
 systemctl restart apache2
 ```
-7) You might also want to edit the default page in `templates/about.html`.
+8) You might also want to edit the default page in `templates/about.html`.
+9) Give the files the correct permissions (recommended especially if you set passwords in `globals.inc.php` instead of the apache config):
+```bash
+find /var/www/slurm-dashboard -type f -exec chmod 640 {} \;
+```
 
 ### Update
 Once you have set up the dashboard, you can use the following bash script to upgrade to a new version. (It might also be helpful for the initial setup.)

--- a/README.MD
+++ b/README.MD
@@ -79,7 +79,8 @@ However, any slurm version `>= 23.11.x` should work. If you encounter any issues
   - If you want JWT authentication:
     - Follow the instructions [in the official documentation](https://slurm.schedmd.com/jwt.html). In short:
       - Make sure that you compiled SLURM with JWT and that you have `libjwt-dev` installed.
-      - Generate a JWT key as follows:
+      - Generate a JWT key as follows.<br>
+        Note: Instead of storing the key in `/var/spool/slurm/statesave` (or whatever `StateSaveLocation` is defined in `slurm.conf`), you might want to store the key e.g. in a `/var/lib/slurm-dashboard` directory instead. In this case, either specify the path in the `slurmrestd.service` explicitly, or make sure that the path exists and is the same on (a) the controller node where `slurmctl` is running, (b) the slurm database node with `slurmdbd` and (c) the node where the dashboard is running and (d) the node where `slurmrestd` is running (if not the same as (c)).
       ```
       dd if=/dev/random of=/var/spool/slurm/statesave/jwt_hs256.key bs=32 count=1
       chown slurm:slurm /var/spool/slurm/statesave/jwt_hs256.key

--- a/README.MD
+++ b/README.MD
@@ -80,7 +80,7 @@ However, any slurm version `>= 23.11.x` should work. If you encounter any issues
     - Follow the instructions [in the official documentation](https://slurm.schedmd.com/jwt.html). In short:
       - Make sure that you compiled SLURM with JWT and that you have `libjwt-dev` installed.
       - Generate a JWT key as follows.<br>
-        Note: Instead of storing the key in `/var/spool/slurm/statesave` (or whatever `StateSaveLocation` is defined in `slurm.conf`), you might want to store the key e.g. in a `/var/lib/slurm-dashboard` directory instead. In this case, either specify the path in the `slurmrestd.service` explicitly, or make sure that the path exists and is the same on (a) the controller node where `slurmctl` is running, (b) the slurm database node with `slurmdbd` and (c) the node where the dashboard is running and (d) the node where `slurmrestd` is running (if not the same as (c)).
+        Note: Instead of storing the key in `/var/spool/slurm/statesave` (or whatever `StateSaveLocation` is defined in `slurm.conf`), you might want to store the key e.g. in a `/var/lib/slurm-dashboard` directory instead. In this case, either specify the path in the `slurmrestd.service` explicitly, or make sure that the path exists and is the same on (a) the controller node where `slurmctld` is running, (b) the slurm database node with `slurmdbd` and (c) the node where the dashboard is running and (d) the node where `slurmrestd` is running (if not the same as (c)).
       ```
       dd if=/dev/random of=/var/spool/slurm/statesave/jwt_hs256.key bs=32 count=1
       chown slurm:slurm /var/spool/slurm/statesave/jwt_hs256.key

--- a/README.MD
+++ b/README.MD
@@ -93,7 +93,7 @@ However, any slurm version `>= 23.11.x` should work. If you encounter any issues
       AuthAltTypes=auth/jwt
       AuthAltParameters=jwt_key=/var/spool/slurm/statesave/jwt_hs256.key
       ```
-      - Restart `slurmctl` and `slurmdbd` (e.g., with `scontrol reconfigure`) and look for errors. Reading the logs (`slurmctld.log`, `slurmdbd.log` and `/var/log/syslog`) might help.
+      - Restart `slurmctl` and `slurmdbd` (e.g., with `scontrol reconfigure`) and look for errors. Reading the logs (`slurmctld.log`, `slurmdbd.log` and `/var/log/syslog`) might help. (While for `slurmctl` `scontrol reconfigure` seems to be sufficient, for `slurmdbd` it was not in my tests. So, please also run `systemctl restart slurmdbd`.)
     - Copy the key to the node where the dashboard is running. Use locations and permissions so that other users cannot read the key. For example, copy the key to `/var/lib/slurm-dashboard` and set the ownership:
     ```
     # Somehow copy the key, e.g. with scp ...

--- a/README.MD
+++ b/README.MD
@@ -125,8 +125,8 @@ However, any slurm version `>= 23.11.x` should work. If you encounter any issues
     WantedBy=multi-user.target
     ```
 
-4) Add correct user to the apache vhost (e.g. `/etc/apache2/sites-enabled/slurm-dashboard.conf`):
-```
+4) Add correct user to the apache vhost (e.g. `/etc/apache2/sites-enabled/slurm-dashboard.conf`). Also set the environment variables accordingly to configure the dashboard. (Alternatively, you could also edit the `globals.inc.php` file to set them, but this is not recommended anymore.) Make sure that your config file is not readable by other users!
+```apacheconf
 <VirtualHost *:80>
     ...
     # Assign user ID
@@ -135,112 +135,49 @@ However, any slurm version `>= 23.11.x` should work. If you encounter any issues
     # Set DocumentRoot to subfolder 'public', e.g.:
     DocumentRoot /var/www/slurm-dashboard/public
     ...
+    
+    # REQUIRED PARAMETERS
+    # Name of the cluster.
+    SetEnv CLUSTER_NAME     "MyCluster"
+    # Name of the admin. Publicly available in error messages.
+    SetEnv ADMIN_NAMES      "John Doe"
+    # Hostname of the login node.
+    SetEnv SLURM_LOGIN_NODE "slurm01.example.com"
+    # Link to a wiki page where one can find more info about the cluster.
+    SetEnv WIKI_LINK        "https://wiki.example.com"
+    
+    # OPTIONAL REST API PARAMETERS
+    # Unix is already the default connection mode
+    # SetEnv CONNECTION_MODE "unix"
+    # REST_API_VERSION must be set only if it cannot be auto detected
+    # SetEnv REST_API_VERSION "v0.0.40"
+    
+    # OPTIONAL LDAP PARAMETERS
+    # URI for LDAP server, e.g. 'dc.example.com'. OPTIONAL
+    SetEnv LDAP_URI            "dc1.example.com"
+    # LDAP base, e.g. 'cn=users,dc=i,dc=example,dc=com'. OPTIONAL
+    SetEnv LDAP_BASE           "cn=users,dc=i,dc=example,dc=com"
+    # LDAP admin user used for querying users, e.g. 'adminuser'. OPTIONAL
+    SetEnv LDAP_ADMIN_USER     "ldapadmin"
+    # LDAP admin password
+    SetEnv LDAP_ADMIN_PASSWORD "password"
+    
+    # OPTIONAL SSH/LOCAL AUTHENTICATION PARAMETERS
+    # URL used for SSH connections, e.g. the login node. OPTIONAL
+    # SetEnv SSH_SERVER_URL     "slurm01.example.com"
+    
+    # OPTIONAL JWT CONFIGURATION
+    # Path to the JWT key. OPTIONAL
+    SetEnv JWT_PATH            "/var/lib/slurm-dashboard/jwt.key"
+    # Username of the Slurm user. Defaults to 'slurm'. OPTIONAL
+    # SetEnv SLURM_USER        "slurm"
+    
+    # Privileged users (OPTIONAL)
+    # SetEnv PRIV_USERS        "user1,user2"
 </VirtualHost>
 ```
 5) Optionally (but strongly recommended), enable SSL etc.
-6) Edit `globals.inc.php` to set the constants (passwords, names, paths, ...):
-```php
-<?php
-
-/**
- * Default value for variables that should be replaced.
- * Do not edit this value, since it is used in other classes to check the respective module is
- * configured or not.
- */
-const TO_BE_REPLACED = '<TO BE REPLACED>';
-
-// BEGIN OF VARIABLES THAT SHOULD BE EDITED
-/**
- * Name of the cluster
- */
-const CLUSTER_NAME = TO_BE_REPLACED;
-/**
- * Name of the admin. Publicly available in error messages.
- */
-const ADMIN_NAMES = TO_BE_REPLACED;
-/**
- * E-Mail address of the admin. Publicly available in error messages.
- */
-const ADMIN_EMAIL = TO_BE_REPLACED;
-/**
- * Hostname of the login node.
- */
-const SLURM_LOGIN_NODE = TO_BE_REPLACED;
-/**
- * Link to a wiki page where one can find more info about the cluster.
- */
-const WIKI_LINK = TO_BE_REPLACED;
-
-// Rest API connection properties
-/**
- * Connection more for connections to slurmrestd.
- * Currently, the only supported value is 'unix'!
- */
-const CONNECTION_MODE = 'unix';
-/**
- * OpenAPI version to use for communication with slurmrestd.
- * Use 'auto' for auto-detection (if supported), or e.g. v0.0.40.
- * Default is 'auto'.
- */
-const REST_API_VERSION = 'auto';
-
-// LDAP configuration
-/**
- * URI for ldap server, e.g. 'dc.example.com'
- * Optional; leave TO_BE_REPLACED if you do not want to use authentication method LDAP.
- */
-const LDAP_URI = TO_BE_REPLACED;
-/**
- * LDAP base, e.g. 'cn=users,dc=i,dc=example,dc=com'
- * Optional; leave TO_BE_REPLACED if you do not want to use authentication method LDAP.
- */
-const LDAP_BASE = TO_BE_REPLACED;
-/**
- * LDAP admin user to query for the users, e.g. 'adminuser'
- * Optional; leave TO_BE_REPLACED if you do not want to use authentication method LDAP.
- */
-const LDAP_ADMIN_USER = TO_BE_REPLACED;
-/**
- * Password for the LDAP admin user.
- * Optional; leave TO_BE_REPLACED if you do not want to use authentication method LDAP.
- */
-const LDAP_ADMIN_PASSWORD = TO_BE_REPLACED;
-
-// SSH configuration for local authentication
-/**
- * Url that is used to connect via SSH to. Can be e.g. the login node.
- * Example: slurm01.example.com
- * Optional; leave TO_BE_REPLACED if you do not want to use authentication method local.
- */
-const SSH_SERVER_URL = TO_BE_REPLACED;
-
-// JWT configuration
-/**
- * Path to the JWT key.
- * Optional; leave TO_BE_REPLACED if you do not want to use JWT authentication.
- */
-const JWT_PATH = TO_BE_REPLACED;
-
-
-/**
- * Grant some users read access to e.g. the list of SLURM users.
- * Admins always have access.
- */
-$privileged_users = array();
-
-/**
- * Username of the slurm user.
- * Defaults to 'slurm'.
- */
-const SLURM_USER = 'slurm';
-
-// END OF VARIABLES THAT SHOULD BE EDITED
-//
-// DO NOT EDIT THIS FILE FROM HERE ON!
-
-...
-```
-7) Start or restart the services:
+6) Start or restart the services:
 ```
 systemctl enable --now slurmrestd
 systemctl enable --now apache2
@@ -248,7 +185,7 @@ systemctl enable --now apache2
 systemctl restart slurmrestd
 systemctl restart apache2
 ```
-8) You might also want to edit the default page in `templates/about.html`.
+7) You might also want to edit the default page in `templates/about.html`.
 
 ### Update
 Once you have set up the dashboard, you can use the following bash script to upgrade to a new version. (It might also be helpful for the initial setup.)
@@ -260,21 +197,6 @@ Once you have set up the dashboard, you can use the following bash script to upg
 # Replace by your web directory
 WEB_DIRECTORY="/var/www/slurm-dashboard"
 DASHBOARD_USER="slurm-dashboard"
-SLURM_USER="slurm"
-SLURM_LOGIN_NODE="slurm.example.com"
-CLUSTER_NAME="Test cluster"
-ADMIN_NAMES="[should contain contact info]"
-ADMIN_EMAIL="[should contain an email address - publicly available]"
-WIKI_LINK="https://example.com/my-slurm-wiki"
-
-LDAP_URI="TO_BE_REPLACED"            # e.g. 'dc.example.com'
-LDAP_BASE="TO_BE_REPLACED"           # e.g. "'cn=users,dc=i,dc=example,dc=com'
-LDAP_ADMIN_USER="TO_BE_REPLACED"     # e.g. 'ldapuser'
-LDAP_ADMIN_PASSWORD="TO_BE_REPLACED" # e.g. 'replaceme'
-
-SSH_SERVER_URL="TO_BE_REPLACED" # e.g. 'localhost'
-
-JWT_PATH="TO_BE_REPLACED" # e.g. /var/lib/slurm-dashboard/jwt_key.key
 # END OF REPLACE-ME
 
 # PRODUCTIVE INSTANCE
@@ -329,25 +251,6 @@ if [[ $REPLY =~ ^[Yy]$ ]]; then
     git branch --set-upstream-to=origin/$branch $branch
     git checkout .
     git pull -f
-
-    set -x
-
-    sed -i "s/const CLUSTER_NAME = TO_BE_REPLACED;/const CLUSTER_NAME = '${CLUSTER_NAME}';/g" globals.inc.php
-    sed -i "s#const ADMIN_NAMES = TO_BE_REPLACED;#const ADMIN_NAMES = '${ADMIN_NAMES}';#g" globals.inc.php
-    sed -i "s#const ADMIN_EMAIL = TO_BE_REPLACED;#const ADMIN_EMAIL = '${ADMIN_EMAIL}';#g" globals.inc.php
-    sed -i "s#const WIKI_LINK = TO_BE_REPLACED;#const WIKI_LINK = '${WIKI_LINK}';#g" globals.inc.php
-    sed -i "s#const SLURM_LOGIN_NODE = TO_BE_REPLACED;#const SLURM_LOGIN_NODE = '${SLURM_LOGIN_NODE}';#g" globals.inc.php
-
-    sed -i "s#const LDAP_URI = TO_BE_REPLACED;#const LDAP_URI = '${LDAP_URI}';#g" globals.inc.php
-    sed -i "s#const LDAP_BASE = TO_BE_REPLACED;#const LDAP_BASE = '${LDAP_BASE}';#g" globals.inc.php
-    sed -i "s#const LDAP_ADMIN_USER = TO_BE_REPLACED;#const LDAP_ADMIN_USER = '${LDAP_ADMIN_USER}';#g" globals.inc.php
-    sed -i "s!const LDAP_ADMIN_PASSWORD = TO_BE_REPLACED;!const LDAP_ADMIN_PASSWORD = '${LDAP_ADMIN_PASSWORD}" globals.inc.php
-
-    sed -i "s#const SSH_SERVER_URL = TO_BE_REPLACED;#const SSH_SERVER_URL = '${SSH_SERVER_URL}';#g" globals.inc.php
-
-    sed -i "s#const JWT_PATH = TO_BE_REPLACED;#const JWT_PATH = '${JWT_PATH}';#g" globals.inc.php
-    
-    sed -i "s#const SLURM_USER = 'slurm';#const SLURM_USER = '${SLURM_USER}';#g" globals.inc.php
 
     find $WEB_DIRECTORY -type f -exec chmod 640 {} \;
 fi

--- a/auth/auth.inc.php
+++ b/auth/auth.inc.php
@@ -173,7 +173,6 @@ namespace auth {
      * @return bool TRUE if the user is privileged, FALSE otherwise.
      */
     function current_user_is_privileged() : bool {
-        global $privileged_users;
-        return current_user_is_admin() || in_array($_SESSION['USER'], $privileged_users, TRUE);
+        return current_user_is_admin() || in_array($_SESSION['USER'], config('PRIV_USERS'), TRUE);
     }
 }

--- a/auth/auth.ldap.inc.php
+++ b/auth/auth.ldap.inc.php
@@ -7,10 +7,6 @@ namespace auth {
      * Authentication via LDAP.
      */
     class LDAP implements AuthenticationMethod {
-        private const URI = LDAP_URI;
-        private const BASE = LDAP_BASE;
-        private const ADMIN_USER = LDAP_ADMIN_USER;
-        private const ADMIN_PASSWORD = LDAP_ADMIN_PASSWORD;
         public const METHOD_NAME = 'ldap';
 
         private mixed $ldapConn;
@@ -21,10 +17,10 @@ namespace auth {
                 return FALSE;
             }
 
-            if (self::URI == TO_BE_REPLACED ||
-                self::BASE == TO_BE_REPLACED ||
-                self::ADMIN_USER == TO_BE_REPLACED ||
-                self::ADMIN_PASSWORD == TO_BE_REPLACED) {
+            if (config('LDAP_URI') == TO_BE_REPLACED ||
+                config('LDAP_BASE') == TO_BE_REPLACED ||
+                config('LDAP_ADMIN_USER') == TO_BE_REPLACED ||
+                config('LDAP_ADMIN_PASSWORD') == TO_BE_REPLACED) {
                 return FALSE;
             }
 
@@ -37,7 +33,7 @@ namespace auth {
          * @return bool TRUE if authentication was successful, FALSE otherwise
          */
         public static function login(string $username, string $password): bool {
-            $ldapConn = ldap_connect(self::URI);
+            $ldapConn = ldap_connect(config('LDAP_URI'));
             if (!$ldapConn) {
                 addError("Could not connect to LDAP server.");
                 return FALSE;
@@ -54,8 +50,8 @@ namespace auth {
             ldap_start_tls($ldapConn); // Start TLS
 
 
-            $ldap_dn = 'cn=' . self::ADMIN_USER . ',' . self::BASE;
-            $ldap_password = self::ADMIN_PASSWORD;
+            $ldap_dn = 'cn=' . config('LDAP_ADMIN_USER') . ',' . config('LDAP_BASE');
+            $ldap_password = config('LDAP_ADMIN_PASSWORD');
 
             $login_ok = FALSE;
 
@@ -64,7 +60,7 @@ namespace auth {
                 // Search for the user
                 $escaped_username = ldap_escape($username, '', LDAP_ESCAPE_FILTER);
                 $filter = "(uid=$escaped_username)";
-                $result = ldap_search($ldapConn, self::BASE, $filter);
+                $result = ldap_search($ldapConn, config('LDAP_BASE'), $filter);
                 $entries = ldap_get_entries($ldapConn, $result);
 
                 if ($entries['count'] > 0) {
@@ -82,7 +78,7 @@ namespace auth {
                     $login_ok = FALSE;
                 }
             } else {
-                addError('LDAP ERROR: Failed to bind as admin. Please contact ' . ADMIN_EMAIL);
+                addError('LDAP ERROR: Failed to bind as admin. Please contact ' . config('ADMIN_EMAIL'));
                 $login_ok = FALSE;
             }
 
@@ -96,7 +92,7 @@ namespace auth {
                 throw new \Exception("LDAP not supported on this server!");
             }
 
-            $this->ldapConn = ldap_connect(self::URI);
+            $this->ldapConn = ldap_connect(config('LDAP_URI'));
             if (!$this->ldapConn) {
                 throw new \Exception("Could not connect to LDAP server.", 403);
             }
@@ -106,12 +102,12 @@ namespace auth {
             ldap_start_tls($this->ldapConn); // Start TLS
 
 
-            $ldap_dn = 'cn=' . self::ADMIN_USER . ',' . self::BASE;
-            $ldap_password = self::ADMIN_PASSWORD;
+            $ldap_dn = 'cn=' . config('LDAP_ADMIN_USER') . ',' . config('LDAP_BASE');
+            $ldap_password = config('LDAP_ADMIN_PASSWORD');
 
             // Bind to the LDAP server
             if (! @ldap_bind($this->ldapConn, $ldap_dn, $ldap_password)) {
-                throw new \Exception('LDAP ERROR: Failed to bind as admin. Please contact ' . ADMIN_EMAIL);
+                throw new \Exception('LDAP ERROR: Failed to bind as admin. Please contact ' . config('ADMIN_EMAIL'));
             }
         }
 
@@ -131,7 +127,7 @@ namespace auth {
                 return apcu_fetch("ldap" . '/' . $filter);
             }
 
-            $result = ldap_search($this->ldapConn, self::BASE, $filter, $attributes, 0, 1);
+            $result = ldap_search($this->ldapConn, config('LDAP_BASE'), $filter, $attributes, 0, 1);
             if ($result === FALSE) {
                 addError("Error in ldap_search");
                 return array();

--- a/auth/auth.local.inc.php
+++ b/auth/auth.local.inc.php
@@ -9,7 +9,6 @@ namespace auth {
      * I.e., this class connects with password authentication to a server via SSH.
      */
     class Local implements AuthenticationMethod {
-        private const SERVER_URL = SSH_SERVER_URL;
         public const METHOD_NAME = 'local';
 
         public static function is_supported(): bool {
@@ -18,7 +17,7 @@ namespace auth {
                 return FALSE;
             }
 
-            if (self::SERVER_URL == TO_BE_REPLACED) {
+            if (config('SSH_SERVER_URL') == TO_BE_REPLACED) {
                 return FALSE;
             }
 
@@ -31,7 +30,7 @@ namespace auth {
          * @return bool TRUE if authentication was successful, FALSE otherwise
          */
         public static function login(string $username, string $password): bool {
-            $ssh = ssh2_connect(self::SERVER_URL);
+            $ssh = ssh2_connect(config('SSH_SERVER_URL'));
             if( $ssh === FALSE ){
                 addError("Could not connect to local authentication server.");
                 return FALSE;

--- a/client/AbstractClient.inc.php
+++ b/client/AbstractClient.inc.php
@@ -191,6 +191,7 @@ abstract class AbstractClient implements Client {
                 'required_nodes' => $json_job['required_nodes'] ?? NULL,
                 'nodes'      => $this->get_nodes($json_job),
                 'qos'        => $json_job['qos'],
+                'nice'       => $json_job['nice'] ?? NULL,
                 'container'  => $json_job['container'],
                 'container_id' => $json_job['container_id'] ?? NULL,
                 'allocating_node' => $json_job['allocating_node'] ?? NULL,
@@ -313,9 +314,30 @@ abstract class AbstractClient implements Client {
         });
     }
 
-    function cancel_job($job_id) : array {
+    function cancel_job(string|int $job_id) : bool {
         $json = RequestFactory::newRequest()->request_delete("job/" . $job_id, 'slurm', static::api_version);
-        return $json;
+        return !isset($json['errors']) || empty($json['errors']);
+    }
+
+    function update_job(array $job_data) : bool{
+        if(isset($job_data['time_limit']) && (
+            !isset($job_data['time_limit']['infinite']) && !isset($job_data['time_limit']['set']) ||
+            isset($job_data['time_liit']['infinite']) && !(intval($job_data['time_limit']['infinite']) == 1 || intval($job_data['time_limit']['infinite']) == 0) ||
+            isset($job_data['time_limit']['set']) && intval($job_data['time_limit']['number']) <= 0
+            )){
+            throw new \exceptions\ValidationException("Wrong format for time_limit.");
+        }
+        if(isset($job_data['nice_value']) && intval($job_data['nice_value']) != $job_data['nice_value']){
+            throw new \exceptions\ValidationException("Wrong format for nice_value.");
+        }
+        if(!isset($job_data['comment'])){
+            throw new \exceptions\ValidationException("Comment was empty.");
+        }
+
+        $json = RequestFactory::newRequest()
+            ->request_post_json("job/" . $job_data['job_id'], 'slurm', static::api_version, $job_data);
+        \utils\show_errors($json);
+        return !isset($json['errors']) || empty($json['errors']);
     }
 
 

--- a/client/AbstractClient.inc.php
+++ b/client/AbstractClient.inc.php
@@ -412,7 +412,10 @@ abstract class AbstractClient implements Client {
             return "?";
         }
 
-        if($job_arr[$param]['set']){
+        if(isset($job_arr[$param]['infinite']) && $job_arr[$param]['infinite'] == 1){
+            return "infinite";
+        }
+        elseif(isset($job_arr[$param]['set']) && $job_arr[$param]['set']){
             $days = floor($job_arr[$param]['number'] / 1440); // 1440 minutes in a day
             $hours = floor(($job_arr[$param]['number'] % 1440) / 60); // 60 minutes in an hour
             $remainingMinutes = $job_arr[$param]['number'] % 60; // Remaining minutes

--- a/client/AbstractClient.inc.php
+++ b/client/AbstractClient.inc.php
@@ -2,6 +2,8 @@
 
 namespace client;
 
+use exceptions\RequestFailedException;
+
 /**
  * Abstract implementation of common functions of versions
  * - v0.0.40
@@ -336,6 +338,24 @@ abstract class AbstractClient implements Client {
 
         $json = RequestFactory::newRequest()
             ->request_post_json("job/" . $job_data['job_id'], 'slurm', static::api_version, $job_data);
+        \utils\show_errors($json);
+        return !isset($json['errors']) || empty($json['errors']);
+    }
+
+    function set_node_state(string $nodename, string $new_state) : bool {
+        if( !in_array($nodename, $this->getNodeList()) ){
+            throw new RequestFailedException(
+                "Node name unknown: " . $nodename,
+                "nodename=$nodename, new_state=$new_state"
+            );
+        }
+
+        $data = array(
+            'state'=>$new_state
+        );
+
+        $json = RequestFactory::newRequest()
+            ->request_post_json("node/" . $nodename, 'slurm', static::api_version, $data);
         \utils\show_errors($json);
         return !isset($json['errors']) || empty($json['errors']);
     }

--- a/client/Client.inc.php
+++ b/client/Client.inc.php
@@ -213,7 +213,8 @@ interface Client{
      */
     function get_maintenances() : array;
 
-    function cancel_job($job_id) : array;
+    function cancel_job(string|int $job_id) : bool;
+    function update_job(array $job_data) : bool;
 }
 
 class ClientFactory {

--- a/client/Client.inc.php
+++ b/client/Client.inc.php
@@ -215,6 +215,8 @@ interface Client{
 
     function cancel_job(string|int $job_id) : bool;
     function update_job(array $job_data) : bool;
+
+    function set_node_state(string $nodename, string $new_state) : bool;
 }
 
 class ClientFactory {

--- a/client/Client.inc.php
+++ b/client/Client.inc.php
@@ -218,7 +218,9 @@ interface Client{
 }
 
 class ClientFactory {
-    public static function newClient($version = REST_API_VERSION) : Client {
+    public static function newClient($version = NULL) : Client {
+        if( $version === NULL )
+            $version = config('REST_API_VERSION');
 
         if( $version == 'auto' ){
             $response = RequestFactory::newRequest()->request_json2("openapi/v3", 0);
@@ -229,7 +231,7 @@ class ClientFactory {
                     "Could not autodetect supported SLURM REST API versions. This is likely, because your SLURM version does not support it, yet.
                     <ul>
                         <li>If you are an admin, please set the parameter <kbd>REST_API_VERSION</kbd> in config.inc.php.</li>
-                        <li>If you are a user and the error persists, please contact " . ADMIN_EMAIL. "</li>
+                        <li>If you are a user and the error persists, please contact " . config('ADMIN_EMAIL') . "</li>
                     </ul>",
                 );
             }

--- a/client/Request.inc.php
+++ b/client/Request.inc.php
@@ -45,8 +45,8 @@ class UnixRequest implements Request {
         $request = "GET /{$namespace}/{$api_version}/{$endpoint} HTTP/1.1\r\n" .
             "Host: localhost\r\n";
         if(\client\utils\jwt\JwtAuthentication::is_supported()){
-            $request .= "X-SLURM-USER-NAME: " . ($_SESSION['USER'] ?? SLURM_USER) . "\r\n";
-            $request .= "X-SLURM-USER-TOKEN: " . \client\utils\jwt\JwtAuthentication::gen_jwt($_SESSION['USER'] ?? SLURM_USER) . "\r\n";
+            $request .= "X-SLURM-USER-NAME: " . ($_SESSION['USER'] ?? config('SLURM_USER')) . "\r\n";
+            $request .= "X-SLURM-USER-TOKEN: " . \client\utils\jwt\JwtAuthentication::gen_jwt($_SESSION['USER'] ?? config('SLURM_USER')) . "\r\n";
         }
         $request .= "Connection: close\r\n\r\n";
         // Send the request
@@ -94,8 +94,8 @@ class UnixRequest implements Request {
         $request = "GET /{$full_endpoint} HTTP/1.1\r\n" .
             "Host: localhost\r\n";
         if(\client\utils\jwt\JwtAuthentication::is_supported()){
-            $request .= "X-SLURM-USER-NAME: " . ($_SESSION['USER'] ?? SLURM_USER) . "\r\n";
-            $request .= "X-SLURM-USER-TOKEN: " . \client\utils\jwt\JwtAuthentication::gen_jwt($_SESSION['USER'] ?? SLURM_USER) . "\r\n";
+            $request .= "X-SLURM-USER-NAME: " . ($_SESSION['USER'] ?? config('SLURM_USER')) . "\r\n";
+            $request .= "X-SLURM-USER-TOKEN: " . \client\utils\jwt\JwtAuthentication::gen_jwt($_SESSION['USER'] ?? config('SLURM_USER')) . "\r\n";
         }
         $request .= "Connection: close\r\n\r\n";
         // Send the request
@@ -243,12 +243,12 @@ class UnixRequest implements Request {
 
 class RequestFactory {
     public static function newRequest() : Request {
-        if(CONNECTION_MODE == 'unix')
+        if(config('CONNECTION_MODE') == 'unix')
             return new UnixRequest();
 
         throw new ConfigurationError(
             "Unknown socket type.",
-            "CONNECTION_MODE has an unknown value, i.e. CONNECTION_MODE=" . CONNECTION_MODE,
+            "CONNECTION_MODE has an unknown value, i.e. CONNECTION_MODE=" . config('CONNECTION_MODE'),
             'Wrong configuration for requests. Could not contact server.
             <ul>
                 <li>If you are an admin, please set the parameter <kbd>CONNECTION_MODE</kbd> in config.inc.php.</li>
@@ -258,12 +258,12 @@ class RequestFactory {
     }
 
     public static function socket_exists() : bool {
-        if(CONNECTION_MODE == 'unix')
+        if(config('CONNECTION_MODE') == 'unix')
             return UnixRequest::socket_exists();
 
         throw new ConfigurationError(
             "Unknown socket type.",
-            "CONNECTION_MODE has an unknown value, i.e. CONNECTION_MODE=" . CONNECTION_MODE,
+            "CONNECTION_MODE has an unknown value, i.e. CONNECTION_MODE=" . config('CONNECTION_MODE'),
             'Wrong configuration for requests. Could not contact server.
             <ul>
                 <li>If you are an admin, please set the parameter <kbd>CONNECTION_MODE</kbd> in config.inc.php.</li>

--- a/client/utils/jwt.inc.php
+++ b/client/utils/jwt.inc.php
@@ -10,19 +10,17 @@ use exceptions\ConfigurationError;
  * authentication at slurmrestd.
  */
 class JwtAuthentication {
-
-    private const JWT_PATH = JWT_PATH;
     private const JWT_DEFAULT_LIFESPAN = 120;
 
     public static function is_supported() : bool {
-        if(self::JWT_PATH == TO_BE_REPLACED)
+        if(config('JWT_PATH') == TO_BE_REPLACED)
             return FALSE;
-        if(! file_exists(self::JWT_PATH) || ! is_readable(self::JWT_PATH) ){
+        if(! file_exists(config('JWT_PATH')) || ! is_readable(config('JWT_PATH')) ){
             syslog(LOG_WARNING, "slurm-dashboard: JWT_PATH is set but cannot be found or read.");
             throw new ConfigurationError(
                 "JWT authentication is enabled but misconfigured.",
-                'JWT authentication path = ' . self::JWT_PATH . ", exists = " .
-                    file_exists(self::JWT_PATH) . ", is readable = " . is_readable(self::JWT_PATH),
+                'JWT authentication path = ' . config('JWT_PATH') . ", exists = " .
+                    file_exists(config('JWT_PATH')) . ", is readable = " . is_readable(config('JWT_PATH')),
                 "JWT authentication failed."
             );
         }
@@ -47,7 +45,7 @@ class JwtAuthentication {
      * @return string JWT key
      */
     static function gen_jwt(string $user, int $lifespan = self::JWT_DEFAULT_LIFESPAN) : string {
-        $signing_key = file_get_contents(self::JWT_PATH);
+        $signing_key = file_get_contents(config('JWT_PATH'));
 
         $header = [
             "alg" => "HS256",

--- a/error.php
+++ b/error.php
@@ -1,7 +1,8 @@
 <?php
-include_once "globals.inc.php";
+include_once __DIR__ . "/globals.inc.php";
 
 // Protect from direct access
+// Should not be necessary since index.php is now located in ./public
 if (!isset($exception) || !($exception instanceof Throwable)) {
     header("Location: /index.php?action=404");
     exit;

--- a/error.php
+++ b/error.php
@@ -57,7 +57,7 @@ if (!isset($exception) || !($exception instanceof Throwable)) {
 <?php else: ?>
     <p>An unknown internal server occurred.</p>
 <?php endif; ?>
-    <p>The dashboard is currently not available. If the error persists, please write an email to <?php print ADMIN_EMAIL; ?>.</p>
+    <p>The dashboard is currently not available. If the error persists, please write an email to <?php print config('ADMIN_EMAIL'); ?>.</p>
 
     <p></p>
 </div>

--- a/exceptions/ValidationException.inc.php
+++ b/exceptions/ValidationException.inc.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace exceptions;
+
+use Throwable;
+require_once __DIR__ . '/BaseException.inc.php';
+
+class ValidationException extends BaseException {
+
+    public function __construct($message='Request failed.',
+                                $debug_info=NULL,
+                                $html_message=NULL,
+                                $code = 0,
+                                Throwable $previous = null){
+        parent::__construct($message, $debug_info, $html_message, $code, $previous);
+    }
+
+}

--- a/globals.inc.php
+++ b/globals.inc.php
@@ -6,91 +6,128 @@
  * configured or not.
  */
 const TO_BE_REPLACED = '<TO BE REPLACED>';
-
-// BEGIN OF VARIABLES THAT SHOULD BE EDITED
 /**
- * Name of the cluster
+ * Helper to read environment vars with fallback.
  */
-const CLUSTER_NAME = TO_BE_REPLACED;
-/**
- * Name of the admin. Publicly available in error messages.
- */
-const ADMIN_NAMES = TO_BE_REPLACED;
-/**
- * E-Mail address of the admin. Publicly available in error messages.
- */
-const ADMIN_EMAIL = TO_BE_REPLACED;
-/**
- * Hostname of the login node.
- */
-const SLURM_LOGIN_NODE = TO_BE_REPLACED;
-/**
- * Link to a wiki page where one can find more info about the cluster.
- */
-const WIKI_LINK = TO_BE_REPLACED;
-
-// Rest API connection properties
-/**
- * Connection more for connections to slurmrestd.
- * Currently, the only supported value is 'unix'!
- */
-const CONNECTION_MODE = 'unix';
-/**
- * OpenAPI version to use for communication with slurmrestd.
- * Use 'auto' for auto-detection (if supported), or e.g. v0.0.40.
- * Default is 'auto'.
- */
-const REST_API_VERSION = 'auto';
-
-// LDAP configuration
-/**
- * URI for ldap server, e.g. 'dc.example.com'
- * Optional; leave TO_BE_REPLACED if you do not want to use authentication method LDAP.
- */
-const LDAP_URI = TO_BE_REPLACED;
-/**
- * LDAP base, e.g. 'cn=users,dc=i,dc=example,dc=com'
- * Optional; leave TO_BE_REPLACED if you do not want to use authentication method LDAP.
- */
-const LDAP_BASE = TO_BE_REPLACED;
-/**
- * LDAP admin user to query for the users, e.g. 'adminuser'
- * Optional; leave TO_BE_REPLACED if you do not want to use authentication method LDAP.
- */
-const LDAP_ADMIN_USER = TO_BE_REPLACED;
-/**
- * Password for the LDAP admin user.
- * Optional; leave TO_BE_REPLACED if you do not want to use authentication method LDAP.
- */
-const LDAP_ADMIN_PASSWORD = TO_BE_REPLACED;
-
-// SSH configuration for local authentication
-/**
- * Url that is used to connect via SSH to. Can be e.g. the login node.
- * Example: slurm01.example.com
- * Optional; leave TO_BE_REPLACED if you do not want to use authentication method local.
- */
-const SSH_SERVER_URL = TO_BE_REPLACED;
-
-// JWT configuration
-/**
- * Path to the JWT key.
- * Optional; leave TO_BE_REPLACED if you do not want to use JWT authentication.
- */
-const JWT_PATH = TO_BE_REPLACED;
-
+function cfg_env(string $name, $default = TO_BE_REPLACED) : string {
+    $value = getenv($name);
+    return ($value !== false && $value !== '') ? $value : $default;
+}
 
 /**
- * Grant some users read access to e.g. the list of SLURM users.
- * Admins always have access.
+ * Main configuration array.
+ * You can override the values here, but it is recommended to set them as environment variables.
  */
-$privileged_users = array();
+$config = [
 
-/**
- * Username of the slurm user.
- * Defaults to 'slurm'.
- */
-const SLURM_USER = 'slurm';
+    /**
+     * Name of the cluster.
+     */
+    'CLUSTER_NAME' => cfg_env('CLUSTER_NAME'),
+
+    /**
+     * Name of the admin. Publicly available in error messages.
+     */
+    'ADMIN_NAMES' => cfg_env('ADMIN_NAMES'),
+
+    /**
+     * E-Mail address of the admin. Publicly available in error messages.
+     */
+    'ADMIN_EMAIL' => cfg_env('ADMIN_EMAIL'),
+
+    /**
+     * Hostname of the login node.
+     */
+    'SLURM_LOGIN_NODE' => cfg_env('SLURM_LOGIN_NODE'),
+
+    /**
+     * Link to a wiki page where one can find more info about the cluster.
+     */
+    'WIKI_LINK' => cfg_env('WIKI_LINK'),
+
+    // ------------------------------------------------------------------
+    // REST API CONNECTION PROPERTIES
+    // ------------------------------------------------------------------
+
+    /**
+     * Connection mode for connections to slurmrestd.
+     * Currently, the only supported value is 'unix'!
+     */
+    'CONNECTION_MODE' => cfg_env('CONNECTION_MODE', 'unix'),
+
+    /**
+     * OpenAPI version to use for communication with slurmrestd.
+     * Use 'auto' for auto-detection (if supported), or e.g. v0.0.40.
+     * Default is 'auto'.
+     */
+    'REST_API_VERSION' => cfg_env('REST_API_VERSION', 'auto'),
+
+    // ------------------------------------------------------------------
+    // LDAP CONFIGURATION
+    // ------------------------------------------------------------------
+
+    /**
+     * URI for LDAP server, e.g. 'dc.example.com'.
+     * Optional; leave TO_BE_REPLACED if you do not want to use LDAP authentication.
+     */
+    'LDAP_URI' => cfg_env('LDAP_URI'),
+
+    /**
+     * LDAP base, e.g. 'cn=users,dc=i,dc=example,dc=com'.
+     * Optional; leave TO_BE_REPLACED if you do not want to use LDAP authentication.
+     */
+    'LDAP_BASE' => cfg_env('LDAP_BASE'),
+
+    /**
+     * LDAP admin user used for querying users, e.g. 'adminuser'.
+     * Optional; leave TO_BE_REPLACED if you do not want to use LDAP authentication.
+     */
+    'LDAP_ADMIN_USER' => cfg_env('LDAP_ADMIN_USER'),
+
+    /**
+     * Password for the LDAP admin user.
+     * Optional; leave TO_BE_REPLACED if you do not want to use LDAP authentication.
+     */
+    'LDAP_ADMIN_PASSWORD' => cfg_env('LDAP_ADMIN_PASSWORD'),
+
+    // ------------------------------------------------------------------
+    // SSH CONFIGURATION (LOCAL AUTHENTICATION)
+    // ------------------------------------------------------------------
+
+    /**
+     * URL used for SSH connections, e.g. the login node.
+     * Example: slurm01.example.com.
+     * Optional; leave TO_BE_REPLACED if you do not want to use local authentication.
+     */
+    'SSH_SERVER_URL' => cfg_env('SSH_SERVER_URL'),
+
+    // ------------------------------------------------------------------
+    // JWT CONFIGURATION
+    // ------------------------------------------------------------------
+
+    /**
+     * Path to the JWT key.
+     * Optional; leave TO_BE_REPLACED if you do not want to use JWT authentication.
+     */
+    'JWT_PATH' => cfg_env('JWT_PATH'),
+
+    // ------------------------------------------------------------------
+    // MISC
+    // ------------------------------------------------------------------
+
+    /**
+     * Username of the Slurm user.
+     * Defaults to 'slurm'.
+     */
+    'SLURM_USER' => cfg_env('SLURM_USER', 'slurm'),
+
+    'PRIV_USERS' => explode(',', getenv('PRIV_USERS') ?: '')
+];
+
+function config($key = null) {
+    global $config;
+    return $key ? $config[$key] : $config;
+}
 
 // END OF VARIABLES THAT SHOULD BE EDITED
 //
@@ -110,10 +147,6 @@ function addError(string $s): void {
     global $errormsg;
     global $error;
     $error = TRUE;
-
-    #$user = isset($_SESSION['USER']) ? $_SESSION['USER'] : "-";
-    #$ip = $_SERVER['REMOTE_ADDR'];
-    #$host = $_SERVER['HTTP_HOST'] ?? '-';
 
     $errormsg .= '<li>' . $s . '</li>';
 }

--- a/globals.inc.php
+++ b/globals.inc.php
@@ -9,9 +9,9 @@ const TO_BE_REPLACED = '<TO BE REPLACED>';
 /**
  * Helper to read environment vars with fallback.
  */
-function cfg_env(string $name, $default = TO_BE_REPLACED) : string {
+function cfg_env(string $name, string $default = TO_BE_REPLACED) : string {
     $value = getenv($name);
-    return ($value !== false && $value !== '') ? $value : $default;
+    return ($value !== FALSE && $value !== '') ? $value : $default;
 }
 
 /**

--- a/public/index.php
+++ b/public/index.php
@@ -22,7 +22,7 @@ require_once __DIR__ . '/../view/users.tpl.php';
 require_once __DIR__ . '/../exceptions/ValidationException.inc.php';
 
 $dao = \client\ClientFactory::newClient();
-$title = "Clusterinfo " . CLUSTER_NAME;
+$title = "Clusterinfo " . $config['CLUSTER_NAME'];
 $contents = "";
 
 if( isset($_GET['action']) && $_GET['action'] == "logout"){
@@ -35,7 +35,7 @@ if( ! $dao->is_available() ){
     throw new \exceptions\RequestFailedException(
         "Cannot create socket.",
         '$dao->is_available() failed',
-        "Cannot create socket. Is <kbd>slurmrestd</kbd> running? Please report this issue to " . ADMIN_EMAIL
+        "Cannot create socket. Is <kbd>slurmrestd</kbd> running? Please report this issue to " . config('ADMIN_EMAIL')
     );
 }
 
@@ -67,7 +67,7 @@ if(!isset($_SESSION['USER'])) {
 
 # About page
 if(isset($_GET['action']) && $_GET['action'] == "about"){
-    $title = "About the cluster " . CLUSTER_NAME;
+    $title = "About the cluster " . config("CLUSTER_NAME");
     $contents .= \view\login\get_about_page();
 }
 

--- a/public/index.php
+++ b/public/index.php
@@ -22,7 +22,7 @@ require_once __DIR__ . '/../view/users.tpl.php';
 require_once __DIR__ . '/../exceptions/ValidationException.inc.php';
 
 $dao = \client\ClientFactory::newClient();
-$title = "Clusterinfo " . $config['CLUSTER_NAME'];
+$title = "Clusterinfo " . config('CLUSTER_NAME');
 $contents = "";
 
 if( isset($_GET['action']) && $_GET['action'] == "logout"){

--- a/templates/edit_job_form.html
+++ b/templates/edit_job_form.html
@@ -1,0 +1,95 @@
+<h2>Modify job {{JOBID}}</h2>
+<p>Here you can edit some values for your job. Most changes can only be done before the job is actually running (i.e., state <kbd>PENDING</kbd>) and some require admin privileges.</p>
+
+<form class="p-4 border" method="post" action="?action=edit-job&job_id={{JOBID}}&do=edit">
+
+    <!-- Job/User Info displayed as text (two-column) -->
+    <div class="row mb-3">
+        <label class="col-md-3 col-form-label">Job ID</label>
+        <div class="col-md-9">
+            <p class="form-control-plaintext mb-0">{{JOBID}}</p>
+            <input type="hidden" name="job_id" value="{{JOBID}}">
+        </div>
+    </div>
+
+    <div class="row mb-3">
+        <label class="col-md-3 col-form-label">Job Name</label>
+        <div class="col-md-9">
+            <p class="form-control-plaintext mb-0">{{JOB_NAME}}</p>
+        </div>
+    </div>
+
+    <div class="row mb-3">
+        <label class="col-md-3 col-form-label">User</label>
+        <div class="col-md-9">
+            <p class="form-control-plaintext mb-0">{{USER_NAME}} ({{USER_ID}})</p>
+        </div>
+    </div>
+
+    <!-- Editable fields (stacked full-width) -->
+    <div class="mb-3">
+        <label for="time_limit" class="form-label">
+            Time Limit (current value: <span class="px-1 py-0 rounded font-monospace" style="background-color:#f8d7da;">{{TIME_LIMIT}}</span>)
+        </label>
+        <input type="text" class="form-control" id="time_limit" name="time_limit"
+               placeholder="e.g. 0-02:00 or infinite">
+        <div class="form-text">
+            New time limit (Format: <kbd>D-HH:MM</kbd> or <kbd>infinite</kbd>). Extensions may require admin approval.
+        </div>
+    </div>
+
+    <div class="mb-3">
+        <label for="nice_value" class="form-label">
+            Nice Value (current value: <span class="px-1 py-0 rounded font-monospace" style="background-color:#f8d7da;">{{NICE_VALUE}}</span>)
+        </label>
+        <input type="number" class="form-control" id="nice_value" name="nice_value"
+               placeholder="0" value="{{NICE_VALUE}}">
+        <div class="form-text">
+            Scheduler nice value. Higher lowers priority. Only admins can set negative values.
+        </div>
+    </div>
+
+    <div class="mb-3">
+        <label for="comment" class="form-label">Comment</label>
+        <textarea class="form-control" id="comment" name="comment" rows="3"
+                  placeholder="Optional note">{{COMMENT}}</textarea>
+        <div class="form-text">Free-form annotation for tracking/documentation.</div>
+    </div>
+
+    <!-- Admin-only fields stacked full-width -->
+    <!--
+        <hr class="my-4">
+        <h5 class="mb-3">Admin-Only Settings</h5>
+
+        <div class="mb-3">
+            <label for="priority" class="form-label">
+                Job Priority (current value: <span class="px-1 py-0 rounded font-monospace" style="background-color:#f8d7da;">{{PRIORITY}}</span>)
+            </label>
+            <input type="number" class="form-control" id="priority" name="priority"
+                   placeholder="e.g. 20000" value="">
+            <div class="form-text">Higher values allow earlier scheduling. Admin-only.</div>
+        </div>
+
+        <div class="mb-3">
+            <label for="qos" class="form-label">
+                QoS (current value: <span class="px-1 py-0 rounded font-monospace" style="background-color:#f8d7da;">{{QOS}}</span>)
+            </label>
+            <input type="text" class="form-control" id="qos" name="qos" placeholder="e.g. normal, high" value="">
+            <div class="form-text">Quality of Service class. Admin-only.</div>
+        </div>
+
+        <div class="mb-3">
+            <label for="partition" class="form-label">
+                Partition (current value: <span class="px-1 py-0 rounded font-monospace" style="background-color:#f8d7da;">{{PARTITION}}</span>)
+            </label>
+            <input type="text" class="form-control" id="partition" name="partition" placeholder="e.g. {{ALL_PARTITIONS}}" value="">
+            <div class="form-text">Cluster partition. Admin-only changes.</div>
+        </div>
+    -->
+        <!-- Submit / Cancel -->
+    <div class="mt-3">
+        <button type="submit" class="btn btn-primary">Apply Changes</button>
+        <a href="?action=jobs" class="btn btn-secondary">Cancel</a>
+    </div>
+
+</form>

--- a/templates/jobinfo.html
+++ b/templates/jobinfo.html
@@ -1,48 +1,48 @@
 <div class="table-responsive">
     <table class="table">
-        <tr>
+        <tr title="Unique numeric identifier assigned by Slurm to this job.">
             <td>Job ID</td>
             <td>{{JOBID}}</td>
         </tr>
-        <tr>
+        <tr title="User-defined name of the job, normally from the --job-name option.">
             <td>Job name</td>
             <td>{{JOBNAME}}</td>
         </tr>
-        <tr>
+        <tr title="Current status of the job in the scheduler (e.g., PENDING, RUNNING, COMPLETED).">
             <td>
                 State:
             </td>
             <td>{{JOB_STATE}}</td>
         </tr>
-        <tr>
+        <tr title="User account under which the job was submitted.">
             <td>User</td>
             <td>{{USER}}</td>
         </tr>
-        <tr>
+        <tr title="Primary Unix group of the submitting user.">
             <td>Group</td>
             <td>{{GROUP}}</td>
         </tr>
-        <tr>
+        <tr title="Slurm account used for charging, priority, and usage tracking.">
             <td>Account</td>
             <td>{{ACCOUNT}}</td>
         </tr>
-        <tr>
+        <tr title="Slurm partitions (queues) where the job is allowed to run.">
             <td>Partitions</td>
             <td>{{PARTITIONS}}</td>
         </tr>
-        <tr>
+        <tr title="Exact command or script path used when submitting the job via sbatch.">
             <td>Submit line</td>
             <td><span class="monospaced">{{SUBMIT_LINE}}</span></td>
         </tr>
-        <tr>
+        <tr title="Directory used as the job’s working directory at submission time.">
             <td>Working directory</td>
             <td><span class="monospaced">{{WORKING_DIRECTORY}}</span></td>
         </tr>
-        <tr>
+        <tr title="Optional comment attached to the job by the user or administrator.">
             <td>Comment</td>
             <td>{{COMMENT}}</td>
         </tr>
-        <tr>
+        <tr title="Exit status returned by the job’s main script or application.">
             <td>Exit code</td>
             <td>{{EXIT_CODE}}</td>
         </tr>
@@ -52,19 +52,19 @@
         <tr>
             <th colspan="2">Nodes</th>
         </tr>
-        <tr>
+        <tr title="Nodes that Slurm has selected for the job but where execution has not yet started.">
             <td>Scheduled Nodes</td>
             <td>{{SCHEDNODES}}</td>
         </tr>
-        <tr>
+        <tr title="Specific nodes requested by the job via e.g. --nodelist.">
             <td>Required Nodes</td>
             <td>{{REQNODES}}</td>
         </tr>
-        <tr>
+        <tr title="List of nodes where the job is running or has run.">
             <td>Nodes</td>
             <td>{{NODES}}</td>
         </tr>
-        <tr>
+        <tr title="Slurm controller or (login) node that performed the resource allocation for this job.">
             <td>Allocating node</td>
             <td>{{ALLOCATING_NODE}}</td>
         </tr>
@@ -73,35 +73,35 @@
         <tr>
             <th colspan="2">Resources</th>
         </tr>
-        <tr>
+        <tr title="Number of CPU cores per socket requested or allocated for the job.">
             <td>Cores per socket</td>
             <td>{{CORES_PER_SOCKET}}</td>
         </tr>
-        <tr>
+        <tr title="Number of logical CPUs allocated for each individual task (--cpus-per-task).">
             <td>CPUs per task</td>
             <td>{{CPUS_PER_TASK}}</td>
         </tr>
-        <tr>
+        <tr title="Detailed information about requested or allocated generic resources (e.g., GPUs).">
             <td>GRES detail</td>
             <td><span class="monospaced">{{GRES_DETAIL}}</span></td>
         </tr>
-        <tr>
+        <tr title="Total number of logical CPUs allocated to the job across all tasks.">
             <td>CPUs</td>
             <td>{{CPUS}}</td>
         </tr>
-        <tr>
+        <tr title="Number of compute nodes allocated to the job.">
             <td>Node count</td>
             <td>{{NODE_COUNT}}</td>
         </tr>
-        <tr>
+        <tr title="Total number of parallel tasks (--ntasks) in the job.">
             <td>Tasks</td>
             <td>{{TASKS}}</td>
         </tr>
-        <tr>
+        <tr title="Memory required per CPU core (--mem-per-cpu).">
             <td>Memory per CPU</td>
             <td>{{MEMORY_PER_CPU}}</td>
         </tr>
-        <tr>
+        <tr title="Memory required per node (--mem).">
             <td>Memory per node</td>
             <td>{{MEMORY_PER_NODE}}</td>
         </tr>
@@ -110,15 +110,15 @@
         <tr>
             <th colspan="2">Time</th>
         </tr>
-        <tr>
+        <tr title="Timestamp when the job was submitted to Slurm.">
             <td>Submit time</td>
             <td>{{SUBMIT_TIME}}</td>
         </tr>
-        <tr>
+        <tr title="Maximum allowed run time for the job (--time).">
             <td>Time limit</td>
             <td>{{TIME_LIMIT}}</td>
         </tr>
-        <tr>
+        <tr title="Latest allowable start time for the job; if it cannot be started in time to meet the deadline, it will not run. Default is no deadline.">
             <td>Deadline</td>
             <td>{{DEADLINE}}</td>
         </tr>
@@ -147,11 +147,11 @@
         <tr>
             <th colspan="2">Other information</th>
         </tr>
-        <tr>
+        <tr title="Hardware or node features required by the job (--constraint).">
             <td>Features</td>
             <td><span class="monospaced">{{FEATURES}}</span></td>
         </tr>
-        <tr>
+        <tr title="Internal Slurm flags describing special handling or defaults applied to the job.">
             <td>Flags</td>
             <td><span class="monospaced">{{FLAGS}}</span></td>
         </tr>
@@ -159,23 +159,23 @@
             <td>Requeue</td>
             <td>{{REQUEUE}}</td>
         </tr>
-        <tr>
+        <tr title="Other jobs that this job depends on; it starts only once dependencies are satisfied.">
             <td>Dependency</td>
             <td><span class="monospaced">{{DEPENDENCY}}</span></td>
         </tr>
-        <tr>
+        <tr title="Other jobs that this job depends on; it starts only once dependencies are satisfied.">
             <td>Transitive dependencies</td>
             <td>{{TRANSITIVE_DEPENDENCIES}}</td>
         </tr>
-        <tr>
+        <tr title="Scheduling priority of the job relative to others in the queue.">
             <td>Priority</td>
             <td>{{PRIORITY}}</td>
         </tr>
-        <tr>
+        <tr title="Quality of Service class that determines limits and priority for the job.">
             <td>QOS</td>
             <td>{{QOS}}</td>
         </tr>
-        <tr>
+        <tr title="User-defined priority adjustment: higher nice values reduce the job’s priority in the scheduler. Set with --nice option.">
             <td>Nice</td>
             <td>{{NICE}}</td>
         </tr>

--- a/templates/jobinfo.html
+++ b/templates/jobinfo.html
@@ -175,5 +175,9 @@
             <td>QOS</td>
             <td>{{QOS}}</td>
         </tr>
+        <tr>
+            <td>Nice</td>
+            <td>{{NICE}}</td>
+        </tr>
     </table>
 </div>

--- a/templates/modal_node_new_state.html
+++ b/templates/modal_node_new_state.html
@@ -1,0 +1,17 @@
+<div class="modal" tabindex="-1" role="dialog" aria-hidden="false" style="display: block">
+    <div class="modal-dialog" role="document">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title">Set state of node {{NODE_NAME}} to {{STATE}}</h5>
+            </div>
+            <div class="modal-body">
+                <p><strong>Do you really want to set node <kbd>{{NODE_NAME}}</kbd> to state {{STATE}}?</strong></p>
+                <p>Note: You must be an admin in order to being allowed to perform this operation!</p>
+            </div>
+            <div class="modal-footer">
+                <a href="?action=node-set-state&nodename={{NODE_NAME}}&state={{STATE}}&do=perform" type="button" class="btn btn-primary btn-danger">Cancel job</a>
+                <a href="?action=usage" type="button" class="btn btn-secondary" data-dismiss="modal">Close</a>
+            </div>
+        </div>
+    </div>
+</div>

--- a/templates/nodeinfo.html
+++ b/templates/nodeinfo.html
@@ -6,7 +6,16 @@
             <td style="width: 100px">
                 State:
             </td>
-            <td style="background-color: {{STATE_COLOR}}">{{STATE}}</td>
+            <td style="background-color: {{STATE_COLOR}}">
+                {{STATE}}
+                <button type="button" class="btn btn-light dropdown-toggle dropdown-toggle-split" data-bs-toggle="dropdown" aria-expanded="false">
+                    <span class="visually-hidden">Toggle Dropdown</span>
+                </button>
+                <ul class="dropdown-menu">
+                    <li><a class="dropdown-item" href="?action=node-set-state&nodename={{NODENAME}}&state=resume">Resume node</a></li>
+                    <li><a class="dropdown-item" href="?action=node-set-state&nodename={{NODENAME}}&state=drain">Drain node</a></li>
+                </ul>
+            </td>
         </tr>
 
         <tr>

--- a/utils.inc.php
+++ b/utils.inc.php
@@ -97,3 +97,7 @@ function slurmTimeLimitFromString(string $time): array {
     // Convert everything to seconds
     return array("set"=> 1, "infinite"=> 0, "number"=>$minutes + 60 * $hours + 1440 * $days);
 }
+
+function format_nullable_int(?int $value, string $suffix = ''): string {
+    return $value === NULL ? '' : (number_format($value, 0, ',', '.') . $suffix);
+}

--- a/utils.inc.php
+++ b/utils.inc.php
@@ -6,6 +6,8 @@
 
 namespace utils;
 
+use InvalidArgumentException;
+
 function get_date_from_unix_if_defined(array $job_arr, string $param, string $default = 'undefined') : string {
     if(! isset($job_arr[$param])){
         return $default;
@@ -67,4 +69,31 @@ function show_errors(array $response) : void {
             addError('<b>' . $error['error'] . '</b> (source: ' . $error['source'] . ')<br>' . $error['description']);
         }
     }
+}
+
+function validate_time_limit(string $str): bool {
+    $pattern = '/^(?:(\d+)-)?((0)?[0-9]|1[0-9]|2[0-3]):([0-5][0-9])$/';
+    return preg_match($pattern, $str) === 1;
+}
+
+function slurmTimeLimitFromString(string $time): array {
+
+    if($time === "infinite"){
+        return array("set"=> 0, "infinite"=> 1);
+    }
+
+    // Regex to match D-HH:MM:SS or HH:MM:SS
+    $pattern = '/^(?:(\d+)-)?((0)?[0-9]|1[0-9]|2[0-3]):([0-5][0-9])$/';
+
+    if (!preg_match($pattern, $time, $matches)) {
+        throw new InvalidArgumentException("Invalid time limit format: $time");
+    }
+
+    // Extract captured groups
+    $days    = isset($matches[1]) ? (int)$matches[1] : 0;
+    $hours   = (int)$matches[2];
+    $minutes = (int)$matches[3];
+
+    // Convert everything to seconds
+    return array("set"=> 1, "infinite"=> 0, "number"=>$minutes + 60 * $hours + 1440 * $days);
 }

--- a/view/job.tpl.php
+++ b/view/job.tpl.php
@@ -29,6 +29,7 @@ function get_slurm_jobinfo(array $query, string $transitive_dependencies = '') :
     $templateBuilder->setParam("REQNODES",    $query['required_nodes'] ?? ''      );
     $templateBuilder->setParam("NODES",             $query['nodes']                     );
     $templateBuilder->setParam("QOS",               $query['qos'] ?? ''           );
+    $templateBuilder->setParam("NICE",              $query['nice'] ?? ''          );
     $templateBuilder->setParam("CONTAINER",         htmlspecialchars($query['container'] ?? '', ENT_QUOTES, 'UTF-8'));
     $templateBuilder->setParam("CONTAINER_ID",      htmlspecialchars($query['container_id'] ?? "", ENT_QUOTES, 'UTF-8'));
     $templateBuilder->setParam("ALLOCATING_NODE",   htmlspecialchars($query['allocating_node'] ?? "", ENT_QUOTES, 'UTF-8'));

--- a/view/job.tpl.php
+++ b/view/job.tpl.php
@@ -11,7 +11,7 @@ function get_slurm_jobinfo(array $query, string $transitive_dependencies = '') :
     $job_state_text = \utils\get_job_state_view($query);
     $user = htmlspecialchars($query['user_name'] . " (" . $query['user_id'] . ')', ENT_QUOTES, 'UTF-8');
     $group = htmlspecialchars($query['group_name'] . " (" . $query['group_id'] . ')', ENT_QUOTES, 'UTF-8');
-    $requeue = $query['requeue'] ? 'yes' : 'no';
+    $requeue = $query['requeue'] ? 'allowed' : 'not allowed';
 
     $templateBuilder = new TemplateLoader("jobinfo.html");
     $templateBuilder->setParam("JOBID",             $query['job_id']                    );
@@ -44,8 +44,8 @@ function get_slurm_jobinfo(array $query, string $transitive_dependencies = '') :
     $templateBuilder->setParam("CPUS",              $query['cpus'] ?? ''           );
     $templateBuilder->setParam("NODE_COUNT",        $query['node_count'] ?? ''     );
     $templateBuilder->setParam("TASKS",             $query['tasks'] ?? ''          );
-    $templateBuilder->setParam("MEMORY_PER_CPU",   $query['memory_per_cpu'] ?? '' );
-    $templateBuilder->setParam("MEMORY_PER_NODE",   $query['memory_per_node'] ?? '' );
+    $templateBuilder->setParam("MEMORY_PER_CPU",    \utils\format_nullable_int($query['memory_per_cpu'], " MB"));
+    $templateBuilder->setParam("MEMORY_PER_NODE",   \utils\format_nullable_int($query['memory_per_node'], " MB"));
     $templateBuilder->setParam("REQUEUE",           $requeue                            );
     $templateBuilder->setParam("SUBMIT_TIME",       $query['submit_time']               );
     $templateBuilder->setParam("TIME_LIMIT",        $query['time_limit']                );

--- a/view/job_history.tpl.php
+++ b/view/job_history.tpl.php
@@ -144,7 +144,7 @@ function get_slurmdb_filter_form(array $filter, array $accounts, array $users, a
         $node_list = '<option></option>' . $node_list;
 
     $templateBuilder = new TemplateLoader("job_filter_form.html");
-    $templateBuilder->setParam("CLUSTER", CLUSTER_NAME);
+    $templateBuilder->setParam("CLUSTER", config("CLUSTER_NAME"));
     $templateBuilder->setParam("ACCOUNT_SELECTS", $account_list);
     $templateBuilder->setParam("JOB_NAME", $filter['job_name'] ?? '');
     $templateBuilder->setParam("CONSTRAINTS", $filter['constraints'] ?? '');

--- a/view/login.tpl.php
+++ b/view/login.tpl.php
@@ -28,10 +28,10 @@ function get_login_form() : string {
 
 function get_about_page() : string {
     $templateBuilder = new TemplateLoader("about.html");
-    $templateBuilder->setParam("CLUSTER_NAME", CLUSTER_NAME);
-    $templateBuilder->setParam("ADMIN_NAMES", ADMIN_NAMES);
-    $templateBuilder->setParam("ADMIN_EMAIL", ADMIN_EMAIL);
-    $templateBuilder->setParam("SLURM_LOGIN_NODE", SLURM_LOGIN_NODE);
-    $templateBuilder->setParam("WIKI_LINK", WIKI_LINK);
+    $templateBuilder->setParam("CLUSTER_NAME", config("CLUSTER_NAME"));
+    $templateBuilder->setParam("ADMIN_NAMES", config('ADMIN_NAMES'));
+    $templateBuilder->setParam("ADMIN_EMAIL", config('ADMIN_EMAIL'));
+    $templateBuilder->setParam("SLURM_LOGIN_NODE", config('SLURM_LOGIN_NODE'));
+    $templateBuilder->setParam("WIKI_LINK", config('WIKI_LINK'));
     return $templateBuilder->build();
 }

--- a/view/slurm-queue.tpl.php
+++ b/view/slurm-queue.tpl.php
@@ -85,6 +85,7 @@ EOF;
             $contents .= <<<EOF
         <ul class="dropdown-menu">
             <li><a class="dropdown-item" href="?action=cancel-job&job_id={$job['job_id']}">Cancel job</a></li>
+            <li><a class="dropdown-item" href="?action=edit-job&job_id={$job['job_id']}">Edit job</a></li>
         </ul>
 EOF;
         }
@@ -100,6 +101,16 @@ EOF;
                          href="?action=cancel-job&job_id={$job['job_id']}"
                          aria-disabled="true">
                         Cancel job
+                      </a>
+                </span>
+                <span class="dropdown-item" 
+                      data-bs-toggle="tooltip" 
+                      data-bs-placement="right"
+                      title="This feature is not supported by the current configuration.">
+                      <a class="dropdown-item disabled" 
+                         href="?action=edit-job&job_id={$job['job_id']}"
+                         aria-disabled="true">
+                        Edit job
                       </a>
                 </span>
             </li>

--- a/view/users.tpl.php
+++ b/view/users.tpl.php
@@ -43,8 +43,7 @@ EOF;
         }
         $contents .=           "</ul></td>";
         $contents .=    "<td>" . $user_arr['default']['account'] . "</td>";
-        global $privileged_users;
-        if( implode(", ", $user_arr['administrator_level']) == 'None' && in_array($user_arr['name'], $privileged_users))
+        if( implode(", ", $user_arr['administrator_level']) == 'None' && in_array($user_arr['name'], config('PRIV_USERS')))
             $contents .=    "<td>Web</td>";
         else
             $contents .=    "<td>" . implode(", ", $user_arr['administrator_level']) . "</td>";


### PR DESCRIPTION
## New features
- Show job nice value in job detail page.
- Contains a general request method for HTTP method `POST` for JSON data.
- Allows for updating some job data.
- Allow the use of environment variables for the config parameters. Therefore, the config parameters are now a (mutable) associative array and not constants any more.
- Allow to update node status to DRAIN and RESUME.

## Small improvements and bug fixes
- Small improvements at cancel job.
- Small changes in the exception handling.
- Fix display of timelimit: If it is infinite, it is correctly displayed as infinite instead of undefined.
- Format memory nicely (with thousands separator and unit) in job view.
- Write "requeue allowed" instead of "yes"/"no"
- Add tooltips for values in slurm queue
- README file