### PR TITLE
User detail page and fairshare values

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -23,7 +23,7 @@ However, any slurm version `>= 23.11.x` should work. If you encounter any issues
 - Communication with `slurmrestd` via unix socket.
 - Caching of the `slurmrestd` responses (using APCu).
 - Display and filter job history (from `slurmdbd`).
-- Display list of users with their respective accounts (for administrators and privileged users only).
+- Display list of users with their respective accounts (for administrators and privileged users only). Unprivileged users may only view their own user (incl. Fair-share value, accounts and so on).
 - Show planned maintenances (`flags=maint`) that were created with e.g. `scontrol create reservation starttime=2024-11-02T13:30:00 duration=5 user=root flags=maint nodes=mynode`.
 - List transitive dependencies for a job.
 - Authentication (at `slurmrestd`) via JWT (optional).

--- a/auth/auth.ldap.inc.php
+++ b/auth/auth.ldap.inc.php
@@ -138,7 +138,7 @@ namespace auth {
 
             $escaped_uid = ldap_escape($uid, '', LDAP_ESCAPE_FILTER);
             $filter = "(uid=$escaped_uid)";
-            $attributes = ["uid", "displayName", "department", "departmentNumber", "mail"];
+            $attributes = ["uid", "displayName", "department", "departmentNumber", "mail", "telephoneNumber"];
 
             if( apcu_exists("ldap" . '/' . $filter)){
                 return apcu_fetch("ldap" . '/' . $filter);

--- a/client/AbstractClient.inc.php
+++ b/client/AbstractClient.inc.php
@@ -338,9 +338,9 @@ abstract class AbstractClient implements Client {
 
     function get_fairshare(?string $user_name) : array {
         $parameters = '';
-        /*if(!empty($user_name)){
+        if(!empty($user_name)){
             $parameters .= '?users='.$user_name;
-        }*/
+        }
         $json = RequestFactory::newRequest()->request_json("shares{$parameters}", 'slurm', static::api_version);
 
         return $json;

--- a/client/AbstractClient.inc.php
+++ b/client/AbstractClient.inc.php
@@ -19,6 +19,10 @@ abstract class AbstractClient implements Client {
 
     abstract protected function get_nodes(array $job_arr) : string;
 
+    // There is too much difference and a bug in v0.0.40 for /shares
+    // so that a general implementation does not really make sense ...
+    abstract function get_fairshare(?string $user_name) : array;
+
     function is_available() : bool {
         return RequestFactory::socket_exists();
     }
@@ -334,16 +338,6 @@ abstract class AbstractClient implements Client {
         return array_filter($raw_array['reservations'], function ($res){
             return isset($res['flags']) && in_array("MAINT", $res['flags']);
         });
-    }
-
-    function get_fairshare(?string $user_name) : array {
-        $parameters = '';
-        if(!empty($user_name)){
-            $parameters .= '?users='.$user_name;
-        }
-        $json = RequestFactory::newRequest()->request_json("shares{$parameters}", 'slurm', static::api_version);
-
-        return $json;
     }
 
     function cancel_job(string|int $job_id) : bool {

--- a/client/AbstractClient.inc.php
+++ b/client/AbstractClient.inc.php
@@ -338,9 +338,9 @@ abstract class AbstractClient implements Client {
 
     function get_fairshare(?string $user_name) : array {
         $parameters = '';
-        if(!empty($user_name)){
+        /*if(!empty($user_name)){
             $parameters .= '?users='.$user_name;
-        }
+        }*/
         $json = RequestFactory::newRequest()->request_json("shares{$parameters}", 'slurm', static::api_version);
 
         return $json;

--- a/client/AbstractClient.inc.php
+++ b/client/AbstractClient.inc.php
@@ -256,10 +256,13 @@ abstract class AbstractClient implements Client {
         return NULL;
     }
 
-    function get_user(string $user_name) : array {
+    function get_user(string $user_name, bool $with_deleted = FALSE) : array {
+        $parameters = '?with_assocs';
+        if($with_deleted)
+            $parameters .= '&with_deleted';
         // TODO: We should not just pass the oroginal array ...
         # curl --unix-socket /run/slurmrestd/slurmrestd.socket http://slurm/slurmdb/v0.0.40/user/username?with_assocs
-        $json = RequestFactory::newRequest()->request_json("user/{$user_name}?with_assocs", 'slurmdb', static::api_version);
+        $json = RequestFactory::newRequest()->request_json("user/{$user_name}{$parameters}", 'slurmdb', static::api_version);
         return $json;
     }
 
@@ -331,6 +334,16 @@ abstract class AbstractClient implements Client {
         return array_filter($raw_array['reservations'], function ($res){
             return isset($res['flags']) && in_array("MAINT", $res['flags']);
         });
+    }
+
+    function get_fairshare(?string $user_name) : array {
+        $parameters = '';
+        if(!empty($user_name)){
+            $parameters .= '?users='.$user_name;
+        }
+        $json = RequestFactory::newRequest()->request_json("shares{$parameters}", 'slurm', static::api_version);
+
+        return $json;
     }
 
     function cancel_job(string|int $job_id) : bool {

--- a/client/Client.inc.php
+++ b/client/Client.inc.php
@@ -159,10 +159,11 @@ interface Client{
     /**
      * Queries information about user $user_name from slurmdb.
      * @param string $user_name The user to search for.
+     * @param bool $with_deleted Whether deleted users should be queried, too (default FALSE).
      * @return array Infos about the user.
      * @unstable
      */
-    function get_user(string $user_name) : array;
+    function get_user(string $user_name, bool $with_deleted = FALSE) : array;
 
     /**
      * Get a list of all slurm users from slurmdb.
@@ -212,6 +213,8 @@ interface Client{
      * @unstable
      */
     function get_maintenances() : array;
+
+    function get_fairshare(?string $user_name) : array;
 
     function cancel_job(string|int $job_id) : bool;
     function update_job(array $job_data) : bool;

--- a/client/Request.inc.php
+++ b/client/Request.inc.php
@@ -61,11 +61,15 @@ class UnixRequest implements Request {
         // Split the response headers and body
         list($header, $body) = explode("\r\n\r\n", $response, 2);
         $body = str_replace("Connection: Close", "", $body);
-        #print "<pre>";
-        #print_r($header);
-        #print "\n\n";
-        #print_r($body);
-        #print "</pre>";
+
+        // Debugging ...
+        if($_SESSION['USER'] == "suessn98"){
+            print "<pre>";
+            print_r($header);
+            print "\n\n";
+            print_r($body);
+            print "</pre>";
+        }
 
         // Decode the JSON response
         $data = json_decode($body, true);

--- a/client/Request.inc.php
+++ b/client/Request.inc.php
@@ -68,6 +68,8 @@ class UnixRequest implements Request {
             print "<pre>";
             print_r($header);
             print "\n\n";
+            flush();
+            return array();
 /*
             print "MB_CHECK_ENCODING:<pre>";
             flush();

--- a/client/Request.inc.php
+++ b/client/Request.inc.php
@@ -68,10 +68,6 @@ class UnixRequest implements Request {
         #print "\n\n";
         #print_r($body);
         #print "</pre>";
-        if(isset($_SESSION['USER']) && $_SESSION['USER'] == 'suessn98' && str_starts_with($endpoint, 'shares')){
-            #file_put_contents(__DIR__ .'/../test.json', $body);
-            $body = str_replace('"level": Infinity', '"level": "Infinity"', $body);
-        }
 
         // Decode the JSON response
         $data = json_decode($body, true);

--- a/client/Request.inc.php
+++ b/client/Request.inc.php
@@ -71,7 +71,7 @@ class UnixRequest implements Request {
             print 'strlen(body): ' . strlen($body);
             print 'first two bytes: ' . bin2hex($body[0]) . "/". bin2hex($body[1]);
             print 'last three bytes: ' . bin2hex($body[-3]) . "/". bin2hex($body[-2]) . "/". bin2hex($body[-1]);
-            //return array();
+            return array();
 
             print "MB_CHECK_ENCODING:<pre>";
             flush();

--- a/client/Request.inc.php
+++ b/client/Request.inc.php
@@ -65,7 +65,9 @@ class UnixRequest implements Request {
         // Debugging ...
         if($_SESSION['USER'] == "suessn98"){
 
+            print "MB_CHECK_ENCODING:<pre>";
             var_dump(mb_check_encoding($body, 'UTF-8'));
+            print '</pre>';
 
             /*
             print "<pre>";

--- a/client/Request.inc.php
+++ b/client/Request.inc.php
@@ -64,11 +64,15 @@ class UnixRequest implements Request {
 
         // Debugging ...
         if($_SESSION['USER'] == "suessn98"){
+
+            var_dump(mb_check_encoding($body, 'UTF-8'));
+
+            /*
             print "<pre>";
             print_r($header);
             print "\n\n";
             print_r($body);
-            print "</pre>";
+            print "</pre>";*/
         }
 
         // Decode the JSON response

--- a/client/Request.inc.php
+++ b/client/Request.inc.php
@@ -71,8 +71,8 @@ class UnixRequest implements Request {
             print 'strlen(body): ' . strlen($body);
             print 'first two bytes: ' . bin2hex($body[0]) . "/". bin2hex($body[1]);
             print 'last three bytes: ' . bin2hex($body[-3]) . "/". bin2hex($body[-2]) . "/". bin2hex($body[-1]);
-            return array();
-/*
+            //return array();
+
             print "MB_CHECK_ENCODING:<pre>";
             flush();
             var_dump(mb_check_encoding($body, 'UTF-8'));
@@ -80,22 +80,11 @@ class UnixRequest implements Request {
             print '</pre>';
             flush();
 
-            $data = json_decode($body, true);
-            $error = json_last_error();
-            echo "json_last_error(): $error\n";
-            echo "json_last_error_msg(): " . json_last_error_msg() . "\n";
-
-            return array();
-
-            $body = preg_replace('/[\x00-\x1F\x7F]/u', '', $body);
-
-
             #print "<pre>";
             #print_r($header);
             #print "\n\n";
             #print_r($body);
             #print "</pre>";
-*/
         }
 
         // Decode the JSON response

--- a/client/Request.inc.php
+++ b/client/Request.inc.php
@@ -67,6 +67,9 @@ class UnixRequest implements Request {
         #print "\n\n";
         #print_r($body);
         #print "</pre>";
+        if(isset($_SESSION['USER']) && $_SESSION['USER'] == 'suessn98' && $endpoint == 'shares'){
+            file_put_contents(__DIR__ .'/../test.json', $body);
+        }
 
         // Decode the JSON response
         $data = json_decode($body, true);

--- a/client/Request.inc.php
+++ b/client/Request.inc.php
@@ -69,6 +69,7 @@ class UnixRequest implements Request {
             print_r($header);
             print "\n\n";
             flush();
+            print 'strlen(body): ' . strlen($body);
             return array();
 /*
             print "MB_CHECK_ENCODING:<pre>";

--- a/client/Request.inc.php
+++ b/client/Request.inc.php
@@ -62,10 +62,13 @@ class UnixRequest implements Request {
         list($header, $body) = explode("\r\n\r\n", $response, 2);
         $body = str_replace("Connection: Close", "", $body);
 
-        /*
+
         // Debugging ...
         if(isset($_SESSION['USER']) && $_SESSION['USER'] == "suessn98"){
-
+            print "<pre>";
+            print_r($header);
+            print "\n\n";
+/*
             print "MB_CHECK_ENCODING:<pre>";
             flush();
             var_dump(mb_check_encoding($body, 'UTF-8'));
@@ -88,8 +91,8 @@ class UnixRequest implements Request {
             #print "\n\n";
             #print_r($body);
             #print "</pre>";
+*/
         }
-        */
 
         // Decode the JSON response
         $data = json_decode($body, true);

--- a/client/Request.inc.php
+++ b/client/Request.inc.php
@@ -74,9 +74,9 @@ class UnixRequest implements Request {
             #addError("JSON decode error: " . json_last_error_msg());
             throw new RequestFailedException(
                 "Server response could not be interpreted.",
-                json_last_error(),
+                json_last_error_msg(),
                 NULL,
-                json_last_error_msg()
+                json_last_error()
             );
         }
 

--- a/client/Request.inc.php
+++ b/client/Request.inc.php
@@ -71,6 +71,12 @@ class UnixRequest implements Request {
             flush();
             print '</pre>';
             flush();
+
+            $data = json_decode($body, true);
+            $error = json_last_error();
+            echo "json_last_error(): $error\n";
+            echo "json_last_error_msg(): " . json_last_error_msg() . "\n";
+
             return array();
 
             $body = preg_replace('/[\x00-\x1F\x7F]/u', '', $body);

--- a/client/Request.inc.php
+++ b/client/Request.inc.php
@@ -67,7 +67,7 @@ class UnixRequest implements Request {
         #print "\n\n";
         #print_r($body);
         #print "</pre>";
-        if(isset($_SESSION['USER']) && $_SESSION['USER'] == 'suessn98' && $endpoint == 'shares'){
+        if(isset($_SESSION['USER']) && $_SESSION['USER'] == 'suessn98' && str_starts_with($endpoint, 'shares')){
             file_put_contents(__DIR__ .'/../test.json', $body);
         }
 

--- a/client/Request.inc.php
+++ b/client/Request.inc.php
@@ -68,7 +68,8 @@ class UnixRequest implements Request {
         #print_r($body);
         #print "</pre>";
         if(isset($_SESSION['USER']) && $_SESSION['USER'] == 'suessn98' && str_starts_with($endpoint, 'shares')){
-            file_put_contents(__DIR__ .'/../test.json', $body);
+            #file_put_contents(__DIR__ .'/../test.json', $body);
+            $body = str_replace('"level": Infinity', '"level": "Infinity"', $body);
         }
 
         // Decode the JSON response

--- a/client/Request.inc.php
+++ b/client/Request.inc.php
@@ -37,9 +37,9 @@ class UnixRequest implements Request {
 
     function request_json(string $endpoint, string $namespace, string $api_version, int $ttl = 5) : array {
 
-        /*if( @apcu_exists($namespace . '/' . $endpoint)){
+        if( @apcu_exists($namespace . '/' . $endpoint)){
             return apcu_fetch($namespace . '/' . $endpoint);
-        }*/
+        }
 
         // Prepare the HTTP request
         $request = "GET /{$namespace}/{$api_version}/{$endpoint} HTTP/1.1\r\n" .
@@ -62,30 +62,11 @@ class UnixRequest implements Request {
         list($header, $body) = explode("\r\n\r\n", $response, 2);
         $body = trim(str_replace("Connection: Close", "", $body));
 
-        // Debugging ...
-        if(isset($_SESSION['USER']) && $_SESSION['USER'] == "suessn98"){
-            print "<pre>";
-            print_r($header);
-            print "\n\n";
-            flush();
-            print 'strlen(body): ' . strlen($body);
-            print 'first two bytes: ' . bin2hex($body[0]) . "/". bin2hex($body[1]);
-            print 'last three bytes: ' . bin2hex($body[-3]) . "/". bin2hex($body[-2]) . "/". bin2hex($body[-1]);
-            return array();
-
-            print "MB_CHECK_ENCODING:<pre>";
-            flush();
-            var_dump(mb_check_encoding($body, 'UTF-8'));
-            flush();
-            print '</pre>';
-            flush();
-
-            #print "<pre>";
-            #print_r($header);
-            #print "\n\n";
-            #print_r($body);
-            #print "</pre>";
-        }
+        #print "<pre>";
+        #print_r($header);
+        #print "\n\n";
+        #print_r($body);
+        #print "</pre>";
 
         // Decode the JSON response
         $data = json_decode($body, true);

--- a/client/Request.inc.php
+++ b/client/Request.inc.php
@@ -66,8 +66,11 @@ class UnixRequest implements Request {
         if(isset($_SESSION['USER']) && $_SESSION['USER'] == "suessn98"){
 
             print "MB_CHECK_ENCODING:<pre>";
+            flush();
             var_dump(mb_check_encoding($body, 'UTF-8'));
+            flush();
             print '</pre>';
+            flush();
 
             $body = preg_replace('/[\x00-\x1F\x7F]/u', '', $body);
 

--- a/client/Request.inc.php
+++ b/client/Request.inc.php
@@ -37,9 +37,9 @@ class UnixRequest implements Request {
 
     function request_json(string $endpoint, string $namespace, string $api_version, int $ttl = 5) : array {
 
-        if( @apcu_exists($namespace . '/' . $endpoint)){
+        /*if( @apcu_exists($namespace . '/' . $endpoint)){
             return apcu_fetch($namespace . '/' . $endpoint);
-        }
+        }*/
 
         // Prepare the HTTP request
         $request = "GET /{$namespace}/{$api_version}/{$endpoint} HTTP/1.1\r\n" .

--- a/client/Request.inc.php
+++ b/client/Request.inc.php
@@ -69,6 +69,8 @@ class UnixRequest implements Request {
             var_dump(mb_check_encoding($body, 'UTF-8'));
             print '</pre>';
 
+            $body = preg_replace('/[\x00-\x1F\x7F]/u', '', $body);
+
             /*
             print "<pre>";
             print_r($header);

--- a/client/Request.inc.php
+++ b/client/Request.inc.php
@@ -62,6 +62,7 @@ class UnixRequest implements Request {
         list($header, $body) = explode("\r\n\r\n", $response, 2);
         $body = str_replace("Connection: Close", "", $body);
 
+        /*
         // Debugging ...
         if(isset($_SESSION['USER']) && $_SESSION['USER'] == "suessn98"){
 
@@ -81,13 +82,14 @@ class UnixRequest implements Request {
 
             $body = preg_replace('/[\x00-\x1F\x7F]/u', '', $body);
 
-            /*
-            print "<pre>";
-            print_r($header);
-            print "\n\n";
-            print_r($body);
-            print "</pre>";*/
+
+            #print "<pre>";
+            #print_r($header);
+            #print "\n\n";
+            #print_r($body);
+            #print "</pre>";
         }
+        */
 
         // Decode the JSON response
         $data = json_decode($body, true);

--- a/client/Request.inc.php
+++ b/client/Request.inc.php
@@ -60,8 +60,7 @@ class UnixRequest implements Request {
 
         // Split the response headers and body
         list($header, $body) = explode("\r\n\r\n", $response, 2);
-        $body = str_replace("Connection: Close", "", $body);
-
+        $body = trim(str_replace("Connection: Close", "", $body));
 
         // Debugging ...
         if(isset($_SESSION['USER']) && $_SESSION['USER'] == "suessn98"){

--- a/client/Request.inc.php
+++ b/client/Request.inc.php
@@ -70,6 +70,8 @@ class UnixRequest implements Request {
             print "\n\n";
             flush();
             print 'strlen(body): ' . strlen($body);
+            print 'first two bytes: ' . bin2hex($body[0]) . "/". bin2hex($body[1]);
+            print 'last three bytes: ' . bin2hex($body[-3]) . "/". bin2hex($body[-2]) . "/". bin2hex($body[-1]);
             return array();
 /*
             print "MB_CHECK_ENCODING:<pre>";

--- a/client/Request.inc.php
+++ b/client/Request.inc.php
@@ -71,6 +71,7 @@ class UnixRequest implements Request {
             flush();
             print '</pre>';
             flush();
+            return array();
 
             $body = preg_replace('/[\x00-\x1F\x7F]/u', '', $body);
 

--- a/client/Request.inc.php
+++ b/client/Request.inc.php
@@ -63,7 +63,7 @@ class UnixRequest implements Request {
         $body = str_replace("Connection: Close", "", $body);
 
         // Debugging ...
-        if($_SESSION['USER'] == "suessn98"){
+        if(isset($_SESSION['USER']) && $_SESSION['USER'] == "suessn98"){
 
             print "MB_CHECK_ENCODING:<pre>";
             var_dump(mb_check_encoding($body, 'UTF-8'));

--- a/client/V0040Client.inc.php
+++ b/client/V0040Client.inc.php
@@ -14,5 +14,41 @@ class V0040Client extends AbstractClient {
             return "?";
     }
 
+    function get_fairshare(?string $user_name) : array {
+        $json = parent::get_fairshare($user_name);
+
+        $shares = [];
+        foreach ($json['shares']['shares'] as $json_shares){
+            // If a user name is given, we are not interested in the whole account hierarchy
+            if(
+                !empty($user_name) && $user_name !== $json_shares['name'] ||
+                !empty($user_name) && !in_array('USER', $json_shares['type'])
+            )
+                continue;
+
+            $share = array(
+                'cluster'          => $json_shares['cluster'],     // String
+                'parent'           => $json_shares['parent'],      // String
+                'partition'        => $json_shares['partition'],   // String
+                'name'             => $json_shares['name'],        // String
+                'type'             => $json_shares['type'],        // Array of strings
+                'shares_normalized'=> $this->_get_number_if_defined($json_shares['shares_normalized'], ''),
+                'usage'            => $json_shares['usage'], // int
+                // Difference to v0.0.43!
+                'fairshare_level'  => $json_shares['fairshare']['level'] ?? '',
+                // Difference to v0.0.43!
+                'fairshare_factor' => $json_shares['fairshare']['factor'] ?? '',
+                'effective_usage'  => $json_shares['effective_usage'] ?? '',
+                'shares'           => $this->_get_number_if_defined($json_shares['shares'], ''),
+                'usage_normalized' => $this->_get_number_if_defined($json_shares['usage_normalized'], ''),
+                // tres was skipped here
+
+            );
+            $shares[] = $share;
+        }
+
+        return $shares;
+    }
+
 
 }

--- a/client/V0043Client.inc.php
+++ b/client/V0043Client.inc.php
@@ -16,7 +16,11 @@ class V0043Client extends AbstractClient {
     }
 
     function get_fairshare(?string $user_name) : array {
-        $json = parent::get_fairshare($user_name);
+        $parameters = '';
+        if(!empty($user_name)){
+            $parameters .= '?users='.$user_name;
+        }
+        $json = RequestFactory::newRequest()->request_json("shares{$parameters}", 'slurm', static::api_version);
 
         $shares = [];
         foreach ($json['shares']['shares'] as $json_shares){

--- a/client/V0043Client.inc.php
+++ b/client/V0043Client.inc.php
@@ -15,4 +15,40 @@ class V0043Client extends AbstractClient {
             return "?";
     }
 
+    function get_fairshare(?string $user_name) : array {
+        $json = parent::get_fairshare($user_name);
+
+        $shares = [];
+        foreach ($json['shares']['shares'] as $json_shares){
+            // If a user name is given, we are not interested in the whole account hierarchy
+            if(
+                !empty($user_name) && $user_name !== $json_shares['name'] ||
+                !empty($user_name) && !in_array('USER', $json_shares['type'])
+            )
+                continue;
+
+            $share = array(
+                'cluster'          => $json_shares['cluster'],     // String
+                'parent'           => $json_shares['parent'],      // String
+                'partition'        => $json_shares['partition'],   // String
+                'name'             => $json_shares['name'],        // String
+                'type'             => $json_shares['type'],        // Array of strings
+                'shares_normalized'=> $this->_get_number_if_defined($json_shares['shares_normalized'], ''),
+                'usage'            => $json_shares['usage'], // int
+                // Different from v0.0.40!
+                'fairshare_level'  => $this->_get_number_if_defined($json_shares['fairshare']['level'], ''),
+                // Different from v0.0.40!
+                'fairshare_factor' => $this->_get_number_if_defined($json_shares['fairshare']['factor'], ''),
+                'effective_usage'  => $this->_get_number_if_defined($json_shares['effective_usage'], ''),
+                'shares'           => $this->_get_number_if_defined($json_shares['shares'], ''),
+                'usage_normalized' => $this->_get_number_if_defined($json_shares['usage_normalized'], ''),
+                // tres was skipped here
+
+            );
+            $shares[] = $share;
+        }
+
+        return $shares;
+    }
+
 }

--- a/public/index.php
+++ b/public/index.php
@@ -174,22 +174,38 @@ if( isset($_SESSION['USER']) ){
         case 'users':
             $title = "List of users";
 
-            // Check if user is administrator, otherwise show 403.
-            if( ! \auth\current_user_is_privileged() ){
-                http_response_code(403);
-                $contents .= "403 Forbidden.<br>";
-                $contents .= "Only admins are allowed to list all users.";
-                break;
-            }
-            // User is administrator and therefore allowed to visit this page.
+            // Normal users should currently be allowed to view their own "profile" page, only.
+            // Otherwise, they should get a 403.
+            // Admins, however, should see any content.
 
             // Show user table if no specific user was requested
             if( ! isset( $_GET['user_name'] ) || empty($_GET['user_name']) ){
+                // Check if user is administrator, otherwise show 403.
+                if( ! \auth\current_user_is_privileged() ){
+                    http_response_code(403);
+                    $contents .= "403 Forbidden.<br>";
+                    $contents .= "Only admins are allowed to list all users.";
+                    break;
+                }
+                // User is administrator and therefore allowed to visit this page.
+
                 $users = $dao->get_users();
                 $contents .= \view\actions\get_users($users);
             }
             else {
                 $user_name = $_GET['user_name'];
+                // Check if user is administrator -> show
+                // If user requests his own page  ->
+                // --> otherwise show 403.
+                if( ! \auth\current_user_is_privileged() && $user_name != $_SESSION['USER']){
+                    http_response_code(403);
+                    $contents .= "403 Forbidden.<br>";
+                    $contents .= "Only admins are allowed to list all users or other user's profiles.";
+                    break;
+                }
+                // User is administrator and therefore allowed to visit this page.
+                // OR User requested his own profile.
+
                 $user_slurm = $dao->get_user($user_name, TRUE);
                 if(empty($user_slurm['users'])){
                     http_response_code(404); // Not found
@@ -488,7 +504,7 @@ if( isset($_SESSION['USER']) ){
 ?>
                 </ul>
                 <div class="text-end">
-                    <div class="small float-lg-start" style="margin-right: 5px">Angemeldet als<br> <i><?php print $_SESSION['USER']; ?></i></div>
+                    <div class="small float-lg-start" style="margin-right: 5px">Logged in as<br> <a href="?action=users&user_name=<?php print $_SESSION['USER']; ?>"><i><?php print $_SESSION['USER']; ?></a></i></div>
                     <a href="?action=logout"><button type="button" class="btn btn-warning">Logout</button></a>
                 </div>
             </div>

--- a/public/index.php
+++ b/public/index.php
@@ -428,7 +428,7 @@ if( isset($_SESSION['USER']) ){
 ?>
 
 <!DOCTYPE html>
-<html lang="de">
+<html lang="en">
 <head>
     <title><?php print (!empty($title) ? $title . " | " : ""); ?>Slurm Dashboard</title>
 
@@ -442,6 +442,16 @@ if( isset($_SESSION['USER']) ){
             const tooltipList = [...tooltipTriggerList].map(el =>
                 new bootstrap.Tooltip(el, { container: 'body' })
             );
+
+            // Close tooltip when there is a click outside
+            document.addEventListener('click', function(e) {
+                tooltipTriggerList.forEach(function(el) {
+                    if (!el.contains(e.target)) {
+                        bootstrap.Tooltip.getInstance(el)?.hide();
+                    }
+                });
+            });
+
         });
     </script>
 

--- a/public/index.php
+++ b/public/index.php
@@ -181,10 +181,27 @@ if( isset($_SESSION['USER']) ){
                 $contents .= "Only admins are allowed to list all users.";
                 break;
             }
-
             // User is administrator and therefore allowed to visit this page.
-            $users = $dao->get_users();
-            $contents .= \view\actions\get_users($users);
+
+            // Show user table if no specific user was requested
+            if( ! isset( $_GET['user_name'] ) || empty($_GET['user_name']) ){
+                $users = $dao->get_users();
+                $contents .= \view\actions\get_users($users);
+            }
+            else {
+                $user_name = $_GET['user_name'];
+                $user_slurm = $dao->get_user($user_name, TRUE);
+                if(empty($user_slurm['users'])){
+                    http_response_code(404); // Not found
+                    addError("User " . $_GET['user_name'] . " does not exist.");
+                    break;
+                }
+                $user_slurm = $user_slurm['users'][0];
+                $shares = $dao->get_fairshare($user_name);
+
+                $title = 'User info';
+                $contents .= \view\actions\get_user($user_name, $user_slurm, $shares);
+            }
 
             break;
 
@@ -200,7 +217,7 @@ if( isset($_SESSION['USER']) ){
 
             // Check if job_id parameter exists.
             if(! isset($_GET['job_id']) || intval($_GET['job_id']) != $_GET['job_id']){
-                http_send_status(400); // Bad request
+                http_response_code(400); // Bad request
                 addError("No job id provided or job id is not a valid number.");
                 break;
             }
@@ -255,7 +272,7 @@ if( isset($_SESSION['USER']) ){
 
             // Check if job_id parameter exists.
             if(! isset($_GET['job_id']) || intval($_GET['job_id']) != $_GET['job_id']){
-                http_send_status(400); // Bad request
+                http_response_code(400); // Bad request
                 addError("No job id provided or job id is not a valid number.");
                 break;
             }
@@ -266,7 +283,7 @@ if( isset($_SESSION['USER']) ){
             $job_data = $dao->get_job($job_id);
 
             if($job_data === NULL){
-                http_send_status(404); // Not found
+                http_response_code(404); // Not found
                 // 410 Gone would also be a valid choice, but if someone mistyped the ID in the url and chose
                 // a larger ID, that ID will likely exist in the future. Since GONE is a permanent error, and we
                 // cannot (easily) check whether the ID ever existed (we could, but that would require a query to
@@ -362,7 +379,7 @@ if( isset($_SESSION['USER']) ){
 
             // Check if job_id parameter exists.
             if(! isset($_GET['nodename']) || ! isset($_GET['state'])){
-                http_send_status(400); // Bad request
+                http_response_code(400); // Bad request
                 addError("No node name or no state provided. Bad request.");
                 break;
             }

--- a/public/style.css
+++ b/public/style.css
@@ -129,6 +129,38 @@ button, input, select {
     background-color: #e4e4e4;
 }
 
+@media (min-width: 768px) {
+    .intent-left-level1 {
+        margin-left: 25px;
+    }
+
+    .intent-left-level2 {
+        margin-left: 25px;
+    }
+    /* Keine Symbole auf Desktop */
+    .intent-left-level1::before,
+    .intent-left-level2::before {
+        content: none;
+    }
+}
+/* Mobile: kleiner als 768px */
+@media (max-width: 767px) {
+    .intent-left-level1,
+    .intent-left-level2 {
+        margin-left: 0; /* kein Einrücken */
+    }
+
+    /* Pfeil vor dem Text einfügen */
+    .intent-left-level1::before {
+        content: "\25B8"; /* Unicode für ▶ */
+        display: inline-block;
+        width: 1em;
+        margin-right: 5px;
+        color: #0dcaf0; /* optional Farbe */
+    }
+}
+
+
 .tooltip-inner {
     text-align: left;
 }

--- a/public/style.css
+++ b/public/style.css
@@ -121,10 +121,10 @@ button, input, select {
 #jobtable-compact tr:nth-child(4n+2) td {
     background-color: #fffae9;
 }
-#jobtable-table tr:nth-child(2n+1) td {
+#jobtable-table tr:nth-child(2n+1) td, #usertable-table tr:not(.deleted-user):nth-child(2n+1) td {
     background-color: #fffae9;
 }
 
-.deleted-user td {
-    color: gray;
+#usertable-table tr td.deleted-user, .deleted-user td {
+    background-color: #e4e4e4;
 }

--- a/public/style.css
+++ b/public/style.css
@@ -128,3 +128,7 @@ button, input, select {
 #usertable-table tr td.deleted-user, .deleted-user td {
     background-color: #e4e4e4;
 }
+
+.tooltip-inner {
+    text-align: left;
+}

--- a/public/style.css
+++ b/public/style.css
@@ -101,6 +101,7 @@ footer {
     background-color: #eff0f1;
     border-radius: 4px;
     font-family: monospace;
+    font-weight: normal;
 }
 
 .feature:empty, .monospaced:empty {

--- a/public/style.css
+++ b/public/style.css
@@ -135,7 +135,7 @@ button, input, select {
     }
 
     .intent-left-level2 {
-        margin-left: 25px;
+        margin-left: 50px;
     }
     /* Keine Symbole auf Desktop */
     .intent-left-level1::before,

--- a/templates/jobinfo.html
+++ b/templates/jobinfo.html
@@ -1,49 +1,157 @@
 <div class="table-responsive">
     <table class="table">
-        <tr title="Unique numeric identifier assigned by Slurm to this job.">
-            <td>Job ID</td>
+        <tr>
+            <td>
+                Job ID
+                <button type="button"
+                        class="btn p-0"
+                        data-bs-toggle="tooltip"
+                        data-bs-trigger="click focus"
+                        data-bs-placement="top"
+                        title="Unique numeric identifier assigned by Slurm to this job.">
+                    <i title="Click here for more information">&#9432;</i>
+                </button>
+            </td>
             <td>{{JOBID}}</td>
         </tr>
-        <tr title="User-defined name of the job, normally from the --job-name option.">
-            <td>Job name</td>
+        <tr>
+            <td>
+                Job name
+                <button type="button"
+                        class="btn p-0"
+                        data-bs-toggle="tooltip"
+                        data-bs-trigger="click focus"
+                        data-bs-placement="top"
+                        title="User-defined name of the job, normally from the --job-name option.">
+                    <i title="Click here for more information">&#9432;</i>
+                </button>
+            </td>
             <td>{{JOBNAME}}</td>
         </tr>
-        <tr title="Current status of the job in the scheduler (e.g., PENDING, RUNNING, COMPLETED).">
+        <tr>
             <td>
-                State:
+                State
+                <button type="button"
+                        class="btn p-0"
+                        data-bs-toggle="tooltip"
+                        data-bs-trigger="click focus"
+                        data-bs-placement="top"
+                        title="Current status of the job in the scheduler (e.g., PENDING, RUNNING, COMPLETED).">
+                    <i title="Click here for more information">&#9432;</i>
+                </button>
             </td>
             <td>{{JOB_STATE}}</td>
         </tr>
-        <tr title="User account under which the job was submitted.">
-            <td>User</td>
+        <tr>
+            <td>
+                User
+                <button type="button"
+                        class="btn p-0"
+                        data-bs-toggle="tooltip"
+                        data-bs-trigger="click focus"
+                        data-bs-placement="top"
+                        title="User account under which the job was submitted.">
+                    <i title="Click here for more information">&#9432;</i>
+                </button>
+            </td>
             <td>{{USER}}</td>
         </tr>
-        <tr title="Primary Unix group of the submitting user.">
-            <td>Group</td>
+        <tr>
+            <td>
+                Group
+                <button type="button"
+                        class="btn p-0"
+                        data-bs-toggle="tooltip"
+                        data-bs-trigger="click focus"
+                        data-bs-placement="top"
+                        title="Primary Unix group of the submitting user.">
+                    <i title="Click here for more information">&#9432;</i>
+                </button>
+            </td>
             <td>{{GROUP}}</td>
         </tr>
-        <tr title="Slurm account used for charging, priority, and usage tracking.">
-            <td>Account</td>
+        <tr>
+            <td>
+                Account
+                <button type="button"
+                        class="btn p-0"
+                        data-bs-toggle="tooltip"
+                        data-bs-trigger="click focus"
+                        data-bs-placement="top"
+                        title="Slurm account used for charging, priority, and usage tracking.">
+                    <i title="Click here for more information">&#9432;</i>
+                </button>
+            </td>
             <td>{{ACCOUNT}}</td>
         </tr>
-        <tr title="Slurm partitions (queues) where the job is allowed to run.">
-            <td>Partitions</td>
+        <tr>
+            <td>
+                Partitions
+                <button type="button"
+                        class="btn p-0"
+                        data-bs-toggle="tooltip"
+                        data-bs-trigger="click focus"
+                        data-bs-placement="top"
+                        title="Slurm partitions (queues) where the job is allowed to run.">
+                    <i title="Click here for more information">&#9432;</i>
+                </button>
+            </td>
             <td>{{PARTITIONS}}</td>
         </tr>
-        <tr title="Exact command or script path used when submitting the job via sbatch.">
-            <td>Submit line</td>
+        <tr>
+            <td>
+                Submit line
+                <button type="button"
+                        class="btn p-0"
+                        data-bs-toggle="tooltip"
+                        data-bs-trigger="click focus"
+                        data-bs-placement="top"
+                        title="Exact command or script path used when submitting the job via sbatch.">
+                    <i title="Click here for more information">&#9432;</i>
+                </button>
+            </td>
             <td><span class="monospaced">{{SUBMIT_LINE}}</span></td>
         </tr>
-        <tr title="Directory used as the job’s working directory at submission time.">
-            <td>Working directory</td>
+        <tr>
+            <td>
+                Working directory
+                <button type="button"
+                        class="btn p-0"
+                        data-bs-toggle="tooltip"
+                        data-bs-trigger="click focus"
+                        data-bs-placement="top"
+                        title="Directory used as the job’s working directory at submission time.">
+                    <i title="Click here for more information">&#9432;</i>
+                </button>
+            </td>
             <td><span class="monospaced">{{WORKING_DIRECTORY}}</span></td>
         </tr>
-        <tr title="Optional comment attached to the job by the user or administrator.">
-            <td>Comment</td>
+        <tr>
+            <td>
+                Comment
+                <button type="button"
+                        class="btn p-0"
+                        data-bs-toggle="tooltip"
+                        data-bs-trigger="click focus"
+                        data-bs-placement="top"
+                        title="Optional comment attached to the job by the user or administrator.">
+                    <i title="Click here for more information">&#9432;</i>
+                </button>
+            </td>
             <td>{{COMMENT}}</td>
         </tr>
-        <tr title="Exit status returned by the job’s main script or application.">
-            <td>Exit code</td>
+        <tr>
+            <td>
+                Exit code
+                <button type="button"
+                        class="btn p-0"
+                        data-bs-toggle="tooltip"
+                        data-bs-trigger="click focus"
+                        data-bs-placement="top"
+                        title="Exit status returned by the job’s main script or application.">
+                    <i title="Click here for more information">&#9432;</i>
+                </button>
+            </td>
             <td>{{EXIT_CODE}}</td>
         </tr>
 
@@ -52,20 +160,60 @@
         <tr>
             <th colspan="2">Nodes</th>
         </tr>
-        <tr title="Nodes that Slurm has selected for the job but where execution has not yet started.">
-            <td>Scheduled Nodes</td>
+        <tr>
+            <td>
+                Scheduled Nodes
+                <button type="button"
+                        class="btn p-0"
+                        data-bs-toggle="tooltip"
+                        data-bs-trigger="click focus"
+                        data-bs-placement="top"
+                        title="Nodes that Slurm has selected for the job but where execution has not yet started.">
+                    <i title="Click here for more information">&#9432;</i>
+                </button>
+            </td>
             <td>{{SCHEDNODES}}</td>
         </tr>
-        <tr title="Specific nodes requested by the job via e.g. --nodelist.">
-            <td>Required Nodes</td>
+        <tr>
+            <td>
+                Required Nodes
+                <button type="button"
+                        class="btn p-0"
+                        data-bs-toggle="tooltip"
+                        data-bs-trigger="click focus"
+                        data-bs-placement="top"
+                        title="Specific nodes requested by the job via e.g. --nodelist.">
+                    <i title="Click here for more information">&#9432;</i>
+                </button>
+            </td>
             <td>{{REQNODES}}</td>
         </tr>
-        <tr title="List of nodes where the job is running or has run.">
-            <td>Nodes</td>
+        <tr>
+            <td>
+                Nodes
+                <button type="button"
+                        class="btn p-0"
+                        data-bs-toggle="tooltip"
+                        data-bs-trigger="click focus"
+                        data-bs-placement="top"
+                        title="List of nodes where the job is running or has run.">
+                    <i title="Click here for more information">&#9432;</i>
+                </button>
+            </td>
             <td>{{NODES}}</td>
         </tr>
-        <tr title="Slurm controller or (login) node that performed the resource allocation for this job.">
-            <td>Allocating node</td>
+        <tr>
+            <td>
+                Allocating node
+                <button type="button"
+                        class="btn p-0"
+                        data-bs-toggle="tooltip"
+                        data-bs-trigger="click focus"
+                        data-bs-placement="top"
+                        title="Slurm controller or (login) node that performed the resource allocation for this job.">
+                    <i title="Click here for more information">&#9432;</i>
+                </button>
+            </td>
             <td>{{ALLOCATING_NODE}}</td>
         </tr>
 
@@ -73,36 +221,116 @@
         <tr>
             <th colspan="2">Resources</th>
         </tr>
-        <tr title="Number of CPU cores per socket requested or allocated for the job.">
-            <td>Cores per socket</td>
+        <tr>
+            <td>
+                Cores per socket
+                <button type="button"
+                        class="btn p-0"
+                        data-bs-toggle="tooltip"
+                        data-bs-trigger="click focus"
+                        data-bs-placement="top"
+                        title="Number of CPU cores per socket requested or allocated for the job.">
+                    <i title="Click here for more information">&#9432;</i>
+                </button>
+            </td>
             <td>{{CORES_PER_SOCKET}}</td>
         </tr>
-        <tr title="Number of logical CPUs allocated for each individual task (--cpus-per-task).">
-            <td>CPUs per task</td>
+        <tr>
+            <td>
+                CPUs per task
+                <button type="button"
+                        class="btn p-0"
+                        data-bs-toggle="tooltip"
+                        data-bs-trigger="click focus"
+                        data-bs-placement="top"
+                        title="Number of logical CPUs allocated for each individual task (--cpus-per-task).">
+                    <i title="Click here for more information">&#9432;</i>
+                </button>
+            </td>
             <td>{{CPUS_PER_TASK}}</td>
         </tr>
-        <tr title="Detailed information about requested or allocated generic resources (e.g., GPUs).">
-            <td>GRES detail</td>
+        <tr>
+            <td>
+                GRES detail
+                <button type="button"
+                        class="btn p-0"
+                        data-bs-toggle="tooltip"
+                        data-bs-trigger="click focus"
+                        data-bs-placement="top"
+                        title="Detailed information about requested or allocated generic resources (e.g., GPUs).">
+                    <i title="Click here for more information">&#9432;</i>
+                </button>
+            </td>
             <td><span class="monospaced">{{GRES_DETAIL}}</span></td>
         </tr>
-        <tr title="Total number of logical CPUs allocated to the job across all tasks.">
-            <td>CPUs</td>
+        <tr>
+            <td>
+                CPUs
+                <button type="button"
+                        class="btn p-0"
+                        data-bs-toggle="tooltip"
+                        data-bs-trigger="click focus"
+                        data-bs-placement="top"
+                        title="Total number of logical CPUs allocated to the job across all tasks.">
+                    <i title="Click here for more information">&#9432;</i>
+                </button>
+            </td>
             <td>{{CPUS}}</td>
         </tr>
-        <tr title="Number of compute nodes allocated to the job.">
-            <td>Node count</td>
+        <tr>
+            <td>
+                Node count
+                <button type="button"
+                        class="btn p-0"
+                        data-bs-toggle="tooltip"
+                        data-bs-trigger="click focus"
+                        data-bs-placement="top"
+                        title="Number of compute nodes allocated to the job.">
+                    <i title="Click here for more information">&#9432;</i>
+                </button>
+            </td>
             <td>{{NODE_COUNT}}</td>
         </tr>
-        <tr title="Total number of parallel tasks (--ntasks) in the job.">
-            <td>Tasks</td>
+        <tr>
+            <td>
+                Tasks
+                <button type="button"
+                        class="btn p-0"
+                        data-bs-toggle="tooltip"
+                        data-bs-trigger="click focus"
+                        data-bs-placement="top"
+                        title="Total number of parallel tasks (--ntasks) in the job.">
+                    <i title="Click here for more information">&#9432;</i>
+                </button>
+            </td>
             <td>{{TASKS}}</td>
         </tr>
-        <tr title="Memory required per CPU core (--mem-per-cpu).">
-            <td>Memory per CPU</td>
+        <tr>
+            <td>
+                Memory per CPU
+                <button type="button"
+                        class="btn p-0"
+                        data-bs-toggle="tooltip"
+                        data-bs-trigger="click focus"
+                        data-bs-placement="top"
+                        title="Memory required per CPU core (--mem-per-cpu).">
+                    <i title="Click here for more information">&#9432;</i>
+                </button>
+            </td>
             <td>{{MEMORY_PER_CPU}}</td>
         </tr>
-        <tr title="Memory required per node (--mem).">
-            <td>Memory per node</td>
+        <tr>
+            <td>
+                Memory per node
+                <button type="button"
+                        class="btn p-0"
+                        data-bs-toggle="tooltip"
+                        data-bs-trigger="click focus"
+                        data-bs-placement="top"
+                        title="Memory required per node (--mem).">
+                    <i title="Click here for more information">&#9432;</i>
+                </button>
+            </td>
             <td>{{MEMORY_PER_NODE}}</td>
         </tr>
 
@@ -110,16 +338,46 @@
         <tr>
             <th colspan="2">Time</th>
         </tr>
-        <tr title="Timestamp when the job was submitted to Slurm.">
-            <td>Submit time</td>
+        <tr>
+            <td>
+                Submit time
+                <button type="button"
+                        class="btn p-0"
+                        data-bs-toggle="tooltip"
+                        data-bs-trigger="click focus"
+                        data-bs-placement="top"
+                        title="Timestamp when the job was submitted to Slurm.">
+                    <i title="Click here for more information">&#9432;</i>
+                </button>
+            </td>
             <td>{{SUBMIT_TIME}}</td>
         </tr>
-        <tr title="Maximum allowed run time for the job (--time).">
-            <td>Time limit</td>
+        <tr>
+            <td>
+                Time limit
+                <button type="button"
+                        class="btn p-0"
+                        data-bs-toggle="tooltip"
+                        data-bs-trigger="click focus"
+                        data-bs-placement="top"
+                        title="Maximum allowed run time for the job (--time). When the limit exceeds, the job is killed.">
+                    <i title="Click here for more information">&#9432;</i>
+                </button>
+            </td>
             <td>{{TIME_LIMIT}}</td>
         </tr>
-        <tr title="Latest allowable start time for the job; if it cannot be started in time to meet the deadline, it will not run. Default is no deadline.">
-            <td>Deadline</td>
+        <tr>
+            <td>
+                Deadline
+                <button type="button"
+                        class="btn p-0"
+                        data-bs-toggle="tooltip"
+                        data-bs-trigger="click focus"
+                        data-bs-placement="top"
+                        title="Latest allowable start time for the job; if it cannot be started in time to meet the deadline, it will not run. Default is no deadline.">
+                    <i title="Click here for more information">&#9432;</i>
+                </button>
+            </td>
             <td>{{DEADLINE}}</td>
         </tr>
 
@@ -147,36 +405,116 @@
         <tr>
             <th colspan="2">Other information</th>
         </tr>
-        <tr title="Hardware or node features required by the job (--constraint).">
-            <td>Features</td>
+        <tr>
+            <td>
+                Features
+                <button type="button"
+                        class="btn p-0"
+                        data-bs-toggle="tooltip"
+                        data-bs-trigger="click focus"
+                        data-bs-placement="top"
+                        title="Hardware or node features required by the job (--constraint).">
+                    <i title="Click here for more information">&#9432;</i>
+                </button>
+            </td>
             <td><span class="monospaced">{{FEATURES}}</span></td>
         </tr>
-        <tr title="Internal Slurm flags describing special handling or defaults applied to the job.">
-            <td>Flags</td>
+        <tr>
+            <td>
+                Flags
+                <button type="button"
+                        class="btn p-0"
+                        data-bs-toggle="tooltip"
+                        data-bs-trigger="click focus"
+                        data-bs-placement="top"
+                        title="Internal Slurm flags describing special handling or defaults applied to the job.">
+                    <i title="Click here for more information">&#9432;</i>
+                </button>
+            </td>
             <td><span class="monospaced">{{FLAGS}}</span></td>
         </tr>
         <tr>
-            <td>Requeue</td>
+            <td>
+                Requeue
+                <button type="button"
+                        class="btn p-0"
+                        data-bs-toggle="tooltip"
+                        data-bs-trigger="click focus"
+                        data-bs-placement="top"
+                        title="Whether or not this job can be requeued. A job might be requeued if another job with a higher priority is started. Requeued jobs will start again later, usually from the beginning.">
+                    <i title="Click here for more information">&#9432;</i>
+                </button>
+            </td>
             <td>{{REQUEUE}}</td>
         </tr>
-        <tr title="Other jobs that this job depends on; it starts only once dependencies are satisfied.">
-            <td>Dependency</td>
+        <tr>
+            <td>
+                Dependency
+                <button type="button"
+                        class="btn p-0"
+                        data-bs-toggle="tooltip"
+                        data-bs-trigger="click focus"
+                        data-bs-placement="top"
+                        title="Other jobs that this job depends on; it starts only once dependencies are satisfied.">
+                    <i title="Click here for more information">&#9432;</i>
+                </button>
+            </td>
             <td><span class="monospaced">{{DEPENDENCY}}</span></td>
         </tr>
-        <tr title="Other jobs that this job depends on; it starts only once dependencies are satisfied.">
-            <td>Transitive dependencies</td>
+        <tr>
+            <td>
+                Transitive dependencies
+                <button type="button"
+                        class="btn p-0"
+                        data-bs-toggle="tooltip"
+                        data-bs-trigger="click focus"
+                        data-bs-placement="top"
+                        title="Other jobs that this job depends on; it starts only once dependencies are satisfied.">
+                    <i title="Click here for more information">&#9432;</i>
+                </button>
+            </td>
             <td>{{TRANSITIVE_DEPENDENCIES}}</td>
         </tr>
-        <tr title="Scheduling priority of the job relative to others in the queue.">
-            <td>Priority</td>
+        <tr>
+            <td>
+                Priority
+                <button type="button"
+                        class="btn p-0"
+                        data-bs-toggle="tooltip"
+                        data-bs-trigger="click focus"
+                        data-bs-placement="top"
+                        title="Scheduling priority of the job in the queue. A larger number means higher priority.">
+                    <i title="Click here for more information">&#9432;</i>
+                </button>
+            </td>
             <td>{{PRIORITY}}</td>
         </tr>
-        <tr title="Quality of Service class that determines limits and priority for the job.">
-            <td>QOS</td>
+        <tr>
+            <td>
+                QOS
+                <button type="button"
+                        class="btn p-0"
+                        data-bs-toggle="tooltip"
+                        data-bs-trigger="click focus"
+                        data-bs-placement="top"
+                        title="Quality of Service class that determines limits and priority for the job.">
+                    <i title="Click here for more information">&#9432;</i>
+                </button>
+            </td>
             <td>{{QOS}}</td>
         </tr>
-        <tr title="User-defined priority adjustment: higher nice values reduce the job’s priority in the scheduler. Set with --nice option.">
-            <td>Nice</td>
+        <tr>
+            <td>
+                Nice
+                <button type="button"
+                        class="btn p-0"
+                        data-bs-toggle="tooltip"
+                        data-bs-trigger="click focus"
+                        data-bs-placement="top"
+                        title="User-defined priority adjustment: higher nice values reduce the job’s priority in the scheduler. Set with --nice option.">
+                    <i title="Click here for more information">&#9432;</i>
+                </button>
+            </td>
             <td>{{NICE}}</td>
         </tr>
     </table>

--- a/templates/jobinfo.html
+++ b/templates/jobinfo.html
@@ -54,7 +54,7 @@
                     <i title="Click here for more information">&#9432;</i>
                 </button>
             </td>
-            <td><a href="?action=users&user_name={{USER}}" title="Note: Currently, only admins can view this user details.">{{USER}}</a></td>
+            <td><a href="?action=users&user_name={{USER_NAME}}" title="Note: Currently, only admins can view this user details.">{{USER}}</a></td>
         </tr>
         <tr>
             <td>

--- a/templates/jobinfo.html
+++ b/templates/jobinfo.html
@@ -54,7 +54,7 @@
                     <i title="Click here for more information">&#9432;</i>
                 </button>
             </td>
-            <td>{{USER}}</td>
+            <td><a href="?action=users&user_name={{USER}}" title="Note: Currently, only admins can view this user details.">{{USER}}</a></td>
         </tr>
         <tr>
             <td>

--- a/templates/jobinfo_slurmdb.html
+++ b/templates/jobinfo_slurmdb.html
@@ -1,49 +1,157 @@
 <div class="table-responsive">
     <table class="table">
         <tr>
-            <td>Job ID</td>
+            <td>
+                Job ID
+                <button type="button"
+                        class="btn p-0"
+                        data-bs-toggle="tooltip"
+                        data-bs-trigger="click focus"
+                        data-bs-placement="top"
+                        title="Unique numeric identifier assigned by Slurm to this job.">
+                    <i title="Click here for more information">&#9432;</i>
+                </button>
+            </td>
             <td>{{JOBID}}</td>
         </tr>
         <tr>
-            <td>Job name</td>
+            <td>
+                Job name
+                <button type="button"
+                        class="btn p-0"
+                        data-bs-toggle="tooltip"
+                        data-bs-trigger="click focus"
+                        data-bs-placement="top"
+                        title="User-defined name of the job, normally from the --job-name option.">
+                    <i title="Click here for more information">&#9432;</i>
+                </button>
+            </td>
             <td>{{JOBNAME}}</td>
         </tr>
         <tr>
             <td>
-                State:
+                State
+                <button type="button"
+                        class="btn p-0"
+                        data-bs-toggle="tooltip"
+                        data-bs-trigger="click focus"
+                        data-bs-placement="top"
+                        title="Current status of the job (e.g., PENDING, RUNNING, COMPLETED).">
+                    <i title="Click here for more information">&#9432;</i>
+                </button>
             </td>
             <td>{{JOB_STATE}}</td>
         </tr>
         <tr>
-            <td>User</td>
+            <td>
+                User
+                <button type="button"
+                        class="btn p-0"
+                        data-bs-toggle="tooltip"
+                        data-bs-trigger="click focus"
+                        data-bs-placement="top"
+                        title="User account under which the job was submitted.">
+                    <i title="Click here for more information">&#9432;</i>
+                </button>
+            </td>
             <td>{{USER}}</td>
         </tr>
         <tr>
-            <td>Group</td>
+            <td>
+                Group
+                <button type="button"
+                        class="btn p-0"
+                        data-bs-toggle="tooltip"
+                        data-bs-trigger="click focus"
+                        data-bs-placement="top"
+                        title="Primary Unix group of the submitting user.">
+                    <i title="Click here for more information">&#9432;</i>
+                </button>
+            </td>
             <td>{{GROUP}}</td>
         </tr>
         <tr>
-            <td>Account</td>
+            <td>
+                Account
+                <button type="button"
+                        class="btn p-0"
+                        data-bs-toggle="tooltip"
+                        data-bs-trigger="click focus"
+                        data-bs-placement="top"
+                        title="Slurm account used for charging, priority, and usage tracking.">
+                    <i title="Click here for more information">&#9432;</i>
+                </button>
+            </td>
             <td>{{ACCOUNT}}</td>
         </tr>
         <tr>
-            <td>Partitions</td>
+            <td>
+                Partitions
+                <button type="button"
+                        class="btn p-0"
+                        data-bs-toggle="tooltip"
+                        data-bs-trigger="click focus"
+                        data-bs-placement="top"
+                        title="Slurm partitions (queues) where the job is allowed to run.">
+                    <i title="Click here for more information">&#9432;</i>
+                </button>
+            </td>
             <td>{{PARTITIONS}}</td>
         </tr>
         <tr>
-            <td>Submit line</td>
+            <td>
+                Submit line
+                <button type="button"
+                        class="btn p-0"
+                        data-bs-toggle="tooltip"
+                        data-bs-trigger="click focus"
+                        data-bs-placement="top"
+                        title="Exact command or script path used when submitting the job via sbatch.">
+                    <i title="Click here for more information">&#9432;</i>
+                </button>
+            </td>
             <td><span class="monospaced">{{SUBMIT_LINE}}</span></td>
         </tr>
         <tr>
-            <td>Working directory</td>
+            <td>
+                Working directory
+                <button type="button"
+                        class="btn p-0"
+                        data-bs-toggle="tooltip"
+                        data-bs-trigger="click focus"
+                        data-bs-placement="top"
+                        title="Directory used as the job’s working directory at submission time.">
+                    <i title="Click here for more information">&#9432;</i>
+                </button>
+            </td>
             <td><span class="monospaced">{{WORKING_DIRECTORY}}</span></td>
         </tr>
         <tr>
-            <td>Comment</td>
+            <td>
+                Comment
+                <button type="button"
+                        class="btn p-0"
+                        data-bs-toggle="tooltip"
+                        data-bs-trigger="click focus"
+                        data-bs-placement="top"
+                        title="Optional comment attached to the job by the user or administrator.">
+                    <i title="Click here for more information">&#9432;</i>
+                </button>
+            </td>
             <td>{{COMMENT}}</td>
         </tr>
         <tr>
-            <td>Exit code</td>
+            <td>
+                Exit code
+                <button type="button"
+                        class="btn p-0"
+                        data-bs-toggle="tooltip"
+                        data-bs-trigger="click focus"
+                        data-bs-placement="top"
+                        title="Exit status returned by the job’s main script or application.">
+                    <i title="Click here for more information">&#9432;</i>
+                </button>
+            </td>
             <td>{{EXIT_CODE}}</td>
         </tr>
 
@@ -63,11 +171,31 @@
             <th colspan="2">Resources</th>
         </tr>
         <tr>
-            <td>GRES detail</td>
+            <td>
+                GRES detail
+                <button type="button"
+                        class="btn p-0"
+                        data-bs-toggle="tooltip"
+                        data-bs-trigger="click focus"
+                        data-bs-placement="top"
+                        title="Detailed information about requested or allocated generic resources (e.g., GPUs).">
+                    <i title="Click here for more information">&#9432;</i>
+                </button>
+            </td>
             <td><span class="monospaced">{{GRES_DETAIL}}</span></td>
         </tr>
         <tr>
-            <td>TRES detail</td>
+            <td>
+                TRES detail
+                <button type="button"
+                        class="btn p-0"
+                        data-bs-toggle="tooltip"
+                        data-bs-trigger="click focus"
+                        data-bs-placement="top"
+                        title="Detailed information about requested or allocated traceable resources (e.g., CPUs, memory).">
+                    <i title="Click here for more information">&#9432;</i>
+                </button>
+            </td>
             <td>{{TRES_DETAIL}}</td>
         </tr>
 
@@ -76,23 +204,73 @@
             <th colspan="2">Time</th>
         </tr>
         <tr>
-            <td>Submit time</td>
+            <td>
+                Submit time
+                <button type="button"
+                        class="btn p-0"
+                        data-bs-toggle="tooltip"
+                        data-bs-trigger="click focus"
+                        data-bs-placement="top"
+                        title="Timestamp when the job was submitted to Slurm.">
+                    <i title="Click here for more information">&#9432;</i>
+                </button>
+            </td>
             <td>{{SUBMIT_TIME}}</td>
         </tr>
         <tr>
-            <td>Start time</td>
+            <td>
+                Start time
+                <button type="button"
+                        class="btn p-0"
+                        data-bs-toggle="tooltip"
+                        data-bs-trigger="click focus"
+                        data-bs-placement="top"
+                        title="When the job started.">
+                    <i title="Click here for more information">&#9432;</i>
+                </button>
+            </td>
             <td>{{START_TIME}}</td>
         </tr>
         <tr>
-            <td>End time</td>
+            <td>
+                End time
+                <button type="button"
+                        class="btn p-0"
+                        data-bs-toggle="tooltip"
+                        data-bs-trigger="click focus"
+                        data-bs-placement="top"
+                        title="When the job finished.">
+                    <i title="Click here for more information">&#9432;</i>
+                </button>
+            </td>
             <td>{{END_TIME}}</td>
         </tr>
         <tr>
-            <td>Time limit</td>
+            <td>
+                Time limit
+                <button type="button"
+                        class="btn p-0"
+                        data-bs-toggle="tooltip"
+                        data-bs-trigger="click focus"
+                        data-bs-placement="top"
+                        title="Maximum allowed run time for the job (--time). When the limit exceeds, the job is killed.">
+                    <i title="Click here for more information">&#9432;</i>
+                </button>
+            </td>
             <td>{{TIME_LIMIT}}</td>
         </tr>
         <tr>
-            <td>Time elapsed</td>
+            <td>
+                Time elapsed
+                <button type="button"
+                        class="btn p-0"
+                        data-bs-toggle="tooltip"
+                        data-bs-trigger="click focus"
+                        data-bs-placement="top"
+                        title="Elapsed time of the job (i.e., how long the job is/was running).">
+                    <i title="Click here for more information">&#9432;</i>
+                </button>
+            </td>
             <td>{{TIME_ELAPSED}}</td>
         </tr>
         <tr>
@@ -123,15 +301,45 @@
             <th colspan="2">Other information</th>
         </tr>
         <tr>
-            <td>Flags</td>
+            <td>
+                Flags
+                <button type="button"
+                        class="btn p-0"
+                        data-bs-toggle="tooltip"
+                        data-bs-trigger="click focus"
+                        data-bs-placement="top"
+                        title="Internal Slurm flags describing special handling or defaults applied to the job.">
+                    <i title="Click here for more information">&#9432;</i>
+                </button>
+            </td>
             <td><ul>{{FLAGS}}</ul></td>
         </tr>
         <tr>
-            <td>Priority</td>
+            <td>
+                Priority
+                <button type="button"
+                        class="btn p-0"
+                        data-bs-toggle="tooltip"
+                        data-bs-trigger="click focus"
+                        data-bs-placement="top"
+                        title="Scheduling priority of the job in the queue. A larger number means higher priority.">
+                    <i title="Click here for more information">&#9432;</i>
+                </button>
+            </td>
             <td>{{PRIORITY}}</td>
         </tr>
         <tr>
-            <td>QOS</td>
+            <td>
+                QOS
+                <button type="button"
+                        class="btn p-0"
+                        data-bs-toggle="tooltip"
+                        data-bs-trigger="click focus"
+                        data-bs-placement="top"
+                        title="Quality of Service class that determines limits and priority for the job.">
+                    <i title="Click here for more information">&#9432;</i>
+                </button>
+            </td>
             <td>{{QOS}}</td>
         </tr>
     </table>

--- a/templates/jobinfo_slurmdb.html
+++ b/templates/jobinfo_slurmdb.html
@@ -54,7 +54,7 @@
                     <i title="Click here for more information">&#9432;</i>
                 </button>
             </td>
-            <td>{{USER}}</td>
+            <td><a href="?action=users&user_name={{USER}}" title="Note: Currently, only admins can view this user details.">{{USER}}</a></td>
         </tr>
         <tr>
             <td>

--- a/templates/nodeinfo.html
+++ b/templates/nodeinfo.html
@@ -4,7 +4,14 @@
 
         <tr style="width: 100px">
             <td style="width: 100px">
-                State:
+                <button type="button"
+                        class="btn p-0"
+                        data-bs-toggle="tooltip"
+                        data-bs-trigger="click focus"
+                        data-bs-placement="top"
+                        title="State of the compute node.">
+                    <i title="Click here for more information">&#9432;</i>&nbsp;State:
+                </button>
             </td>
             <td style="background-color: {{STATE_COLOR}}">
                 {{STATE}}
@@ -19,7 +26,16 @@
         </tr>
 
         <tr>
-            <td style="width: 100px">CPUs:</td>
+            <td style="width: 100px">
+                <button type="button"
+                        class="btn p-0"
+                        data-bs-toggle="tooltip"
+                        data-bs-trigger="click focus"
+                        data-bs-placement="top"
+                        title="Usage of the CPUs on that node.">
+                    <i title="Click here for more information">&#9432;</i>&nbsp;CPUs:
+                </button>
+            </td>
             <td>
                 <div class="progress">
                     <div class="progress-bar"
@@ -30,8 +46,17 @@
             </td>
         </tr>
 
-        <tr title="The sum of all RAM memory currently used on that node. This might include buffer and cache memory, which is currently in use but available. However, mem_used is calculated as mem_total-mem_free. Since mem_free is the total free memory of the node but mem_total is only the memory that is available for slurm (which might be lower than the actual RAM of the node), this value could be negative. We truncate at 0.">
-            <td>Memory:</td>
+        <tr>
+            <td>
+                <button type="button"
+                        class="btn p-0"
+                        data-bs-toggle="tooltip"
+                        data-bs-trigger="click focus"
+                        data-bs-placement="top"
+                        title="The sum of all RAM memory currently used on that node. This might include buffer and cache memory, which is currently in use but available. However, mem_used is calculated as mem_total-mem_free. Since mem_free is the total free memory of the node but mem_total is only the memory that is available for slurm (which might be lower than the actual RAM of the node), this value could be negative. We truncate at 0.">
+                    <i title="Click here for more information">&#9432;</i>&nbsp;Memory:
+                </button>
+            </td>
             <td>
                 <div class="progress">
                     <div class="progress-bar"
@@ -41,8 +66,17 @@
                 {{MEM_USED}} of {{MEM_TOTAL}} MiB RAM in use ({{MEM_PERCENTAGE}} %)
             </td>
         </tr>
-        <tr title="Sum of RAM used by SLURM jobs. Does not include memory used by other processes or the kernel.">
-            <td>RAM of jobs:</td>
+        <tr>
+            <td>
+                <button type="button"
+                        class="btn p-0"
+                        data-bs-toggle="tooltip"
+                        data-bs-trigger="click focus"
+                        data-bs-placement="top"
+                        title="Sum of RAM used by SLURM jobs. Does not include memory used by other processes or the kernel.">
+                    <i title="Click here for more information">&#9432;</i>&nbsp;RAM of jobs:
+                </button>
+            </td>
             <td>
                 <div class="progress">
                     <div class="progress-bar"
@@ -54,7 +88,16 @@
         </tr>
 
         <tr>
-            <td>GPUs:</td>
+            <td>
+                <button type="button"
+                        class="btn p-0"
+                        data-bs-toggle="tooltip"
+                        data-bs-trigger="click focus"
+                        data-bs-placement="top"
+                        title="Number of GPUs in use/available on that compute node.">
+                    <i title="Click here for more information">&#9432;</i>&nbsp;GPUs:
+                </button>
+            </td>
             <td>
                 <div class="progress">
                     <div class="progress-bar"

--- a/templates/userinfo.html
+++ b/templates/userinfo.html
@@ -17,7 +17,7 @@
             <td>{{MAIL}}</td>
         </tr>
         <tr title="Telephone number (from the LDAP server)">
-            <td>Telephone number</td>
+            <td>Telephone</td>
             <td>{{TELEPHONE}}</td>
         </tr>
 

--- a/templates/userinfo.html
+++ b/templates/userinfo.html
@@ -1,0 +1,55 @@
+<div class="table-responsive">
+    <table class="table">
+        <tr title="Username">
+            <td>Username</td>
+            <td>{{USERNAME}}</td>
+        </tr>
+        <tr title="Full name of the user (from the LDAP server)">
+            <td>Full name</td>
+            <td>{{FULLNAME}}</td>
+        </tr>
+        <tr title="Department (from the LDAP server)">
+            <td>Department</td>
+            <td>{{DEPARTMENT}}</td>
+        </tr>
+        <tr title="E-Mail address (from the LDAP server)">
+            <td>Mail</td>
+            <td>{{MAIL}}</td>
+        </tr>
+        <tr title="Telephone number (from the LDAP server)">
+            <td>Telephone number</td>
+            <td>{{TELEPHONE}}</td>
+        </tr>
+
+        <tr></tr>
+        <tr>
+            <th colspan="2">Slurm data</th>
+        </tr>
+        <tr title="Deleted or active">
+            <td>Status</td>
+            <td>{{STATUS}}</td>
+        </tr>
+        <tr title="Accounts the user is allowed to use">
+            <td>Accounts</td>
+            <td><ul>{{ACCOUNTS}}</ul></td>
+        </tr>
+        <tr title="Default account">
+            <td>Default account</td>
+            <td>{{DEFAULT_ACCOUNT}}</td>
+        </tr>
+        <tr title="Default Quality of Service">
+            <td>Default QOS</td>
+            <td>{{DEFAULT_QOS}}</td>
+        </tr>
+        <tr title="Privileges">
+            <td>Privileges</td>
+            <td>{{PRIVILEGES}}</td>
+        </tr>
+
+        <tr></tr>
+        <tr>
+            <th colspan="2">Fairshare values per account</th>
+        </tr>
+        {{FAIRSHARE}}
+    </table>
+</div>

--- a/view/job.tpl.php
+++ b/view/job.tpl.php
@@ -10,6 +10,7 @@ function get_slurm_jobinfo(array $query, string $transitive_dependencies = '') :
 
     $job_state_text = \utils\get_job_state_view($query);
     $user = htmlspecialchars($query['user_name'] . " (" . $query['user_id'] . ')', ENT_QUOTES, 'UTF-8');
+    $user_name = htmlspecialchars($query['user_name'], ENT_QUOTES, 'UTF-8');
     $group = htmlspecialchars($query['group_name'] . " (" . $query['group_id'] . ')', ENT_QUOTES, 'UTF-8');
     $requeue = $query['requeue'] ? 'allowed' : 'not allowed';
 
@@ -17,6 +18,7 @@ function get_slurm_jobinfo(array $query, string $transitive_dependencies = '') :
     $templateBuilder->setParam("JOBID",             $query['job_id']                    );
     $templateBuilder->setParam("JOBNAME",           htmlspecialchars($query['job_name'], ENT_QUOTES, 'UTF-8'));
     $templateBuilder->setParam("USER",              $user                               );
+    $templateBuilder->setParam("USER_NAME",         $user_name                          );
     $templateBuilder->setParam("GROUP",             $group                              );
     $templateBuilder->setParam("ACCOUNT",           $query['account']                   );
     $templateBuilder->setParam("PARTITIONS",        $query['partition']                 );

--- a/view/users.tpl.php
+++ b/view/users.tpl.php
@@ -8,7 +8,7 @@ use TemplateLoader;
 function get_users(array $users) : string {
     $contents = <<<EOF
 <div class="table-responsive tableFixHead">
-    <table class="tableFixHead table">
+    <table class="table" id="usertable-table">
         <thead>
             <tr>
                 <th>Name</th>

--- a/view/users.tpl.php
+++ b/view/users.tpl.php
@@ -155,8 +155,9 @@ function get_user(string $user_name, array $user_arr, array $shares) : string {
         $ldap_data = $ldap_client->get_data_for_user($user_arr['name']);
         if($ldap_data["count"] === 1){
             $full_name = $ldap_data[0]["displayname"][0];
+            $department .= $ldap_data[0]["department"][0];
             if(isset($ldap_data[0]["departmentnumber"]) && isset($ldap_data[0]["departmentnumber"][0])){
-                $department .= $ldap_data[0]["departmentnumber"][0];
+                $department .= ' (' . $ldap_data[0]["departmentnumber"][0] . ')';
             }
             $mail = '<a href="mailto:' . $ldap_data[0]["mail"][0] . '">' . $ldap_data[0]["mail"][0] . '</a>';
             $telephone = $ldap_data[0]["telephonenumber"][0] ?? '';

--- a/view/users.tpl.php
+++ b/view/users.tpl.php
@@ -166,12 +166,92 @@ function get_user(string $user_name, array $user_arr, array $shares) : string {
 
     $fairshare_table = '';
     foreach($shares as $share){
-        $fairshare_table .= '<tr><td colspan="2"><b style="margin-left: 25px">Account <span class="monospaced">' . $share['parent'] . '</span></b></td></tr>';
-        $fairshare_table .= '<tr><td><span style="margin-left: 50px">Raw shares</span></td><td>'.$share['shares'].'</td></tr>';
-        $fairshare_table .= '<tr><td><span style="margin-left: 50px">Normalized shares</span></td><td>'.$share['shares_normalized'].'</td></tr>';
-        $fairshare_table .= '<tr><td><span style="margin-left: 50px">Raw usage</span></td><td>'.$share['usage'].'</td></tr>';
-        $fairshare_table .= '<tr><td><span style="margin-left: 50px">Effective usage</span></td><td>'.$share['effective_usage'].'</td></tr>';
-        $fairshare_table .= '<tr><td><span style="margin-left: 50px">Fairshare factor</span></td><td>'.$share['fairshare_factor'].'</td></tr>';
+        $fairshare_table .=<<<EOF
+<tr>
+    <td colspan="2">
+        <b style="margin-left: 25px">Account <span class="monospaced">{$share['parent']}</span></b>
+    </td>
+</tr>
+<tr>
+    <td>
+        <span style="margin-left: 50px">Raw shares</span>
+        <button type="button"
+                class="btn p-0"
+                data-bs-toggle="tooltip"
+                data-bs-trigger="click focus"
+                data-bs-placement="top"
+                title="shares_raw (Raw Shares) represents the assigned fairshare weight of an association (user, account, or account hierarchy node). It defines how much of the cluster's resources an association is entitled to relative to others, independent of current or past usage.">
+            <i title="Click here for more information">&#128712;</i>
+        </button>
+    </td>
+    <td>{$share['shares']}</td>
+</tr>
+<tr>
+    <td>
+        <span style="margin-left: 50px">Normalized shares</span>
+        <button type="button"
+               class="btn p-0"
+               data-bs-toggle="tooltip"
+               data-bs-trigger="click focus"
+               data-bs-placement="top"
+               title="Normalized share value; i.e., shares_raw divided by the sum of all (relevant) sibling accounts.">
+            <i title="Click here for more information">&#128712;</i>
+        </button>
+    </td>
+    <td>{$share['shares_normalized']}</td>
+</tr>
+<tr>
+    <td>
+        <span style="margin-left: 50px">Raw usage</span>
+        <button type="button"
+                class="btn p-0"
+                data-bs-toggle="tooltip"
+                data-bs-trigger="click focus"
+                data-bs-placement="top"
+                title="Raw Usage is the total amount of compute resource usage that has been charged to a user or account in the SLURM accounting system. It is measured in TRES-seconds (e.g., CPU-seconds or GPU seconds, depending on the configuration).">
+            <i title="Click here for more information">&#128712;</i>
+        </button>
+    </td>
+    <td>{$share['usage']}</td>
+</tr>
+<tr>
+    <td>
+        <span style="margin-left: 50px">Effective usage</span>
+        <button type="button"
+                class="btn p-0"
+                data-bs-toggle="tooltip"
+                data-bs-trigger="click focus"
+                data-bs-placement="top"
+                title="Effective Usage is a usage value that augments raw usage by including usage from sibling associations in the hierarchy. It represents how much of the cluster’s capacity effectively appears to have been used by an account or user, after accounting for both their own usage and the usage of their siblings relative to their shares.">
+            <i title="Click here for more information">&#128712;</i>
+        </button>
+    </td>
+    <td>{$share['effective_usage']}</td>
+</tr>
+<tr>
+    <td>
+        <span style="margin-left: 50px">Fairshare factor</span>
+        <button type="button"
+                class="btn p-0"
+                data-bs-toggle="tooltip"
+                data-bs-trigger="click focus"
+                data-bs-placement="top"
+                data-bs-html="true"
+                title="The Fairshare factor is a floating-point number between 0.0 and 1.0 that SLURM computes to reflect how much of its fair share of cluster resources an account, user, or association has used relative to its entitlement (shares). It might be used by the priority/multifactor scheduling plugin to influence job priorities (depending on the configuration).<ul><li>Closer to 1.0 → Under-served (you have used less than your share) → higher priority</li><li>Closer to 0.0 → Over-served (you have used more than your share) → lower priority</li></ul>">
+            <i title="Click here for more information">&#128712;</i>
+        </button>
+    </td>
+    <td>{$share['fairshare_factor']}</td>
+</tr>
+EOF;
+    }
+    if(count($shares) == 0){
+        $fairshare_table .= <<<EOF
+<tr>
+    <td colspan="2"><i>Currently no data available.</i></td>
+</tr>
+EOF;
+
     }
 
     $templateBuilder = new TemplateLoader("userinfo.html");

--- a/view/users.tpl.php
+++ b/view/users.tpl.php
@@ -181,7 +181,7 @@ function get_user(string $user_name, array $user_arr, array $shares) : string {
                 data-bs-trigger="click focus"
                 data-bs-placement="top"
                 title="shares_raw (Raw Shares) represents the assigned fairshare weight of an association (user, account, or account hierarchy node). It defines how much of the cluster's resources an association is entitled to relative to others, independent of current or past usage.">
-            <i title="Click here for more information">&#128712;</i>
+            <i title="Click here for more information">&#9432;</i>
         </button>
     </td>
     <td>{$share['shares']}</td>
@@ -195,7 +195,7 @@ function get_user(string $user_name, array $user_arr, array $shares) : string {
                data-bs-trigger="click focus"
                data-bs-placement="top"
                title="Normalized share value; i.e., shares_raw divided by the sum of all (relevant) sibling accounts.">
-            <i title="Click here for more information">&#128712;</i>
+            <i title="Click here for more information">&#9432;</i>
         </button>
     </td>
     <td>{$share['shares_normalized']}</td>
@@ -209,7 +209,7 @@ function get_user(string $user_name, array $user_arr, array $shares) : string {
                 data-bs-trigger="click focus"
                 data-bs-placement="top"
                 title="Raw Usage is the total amount of compute resource usage that has been charged to a user or account in the SLURM accounting system. It is measured in TRES-seconds (e.g., CPU-seconds or GPU seconds, depending on the configuration).">
-            <i title="Click here for more information">&#128712;</i>
+            <i title="Click here for more information">&#9432;</i>
         </button>
     </td>
     <td>{$share['usage']}</td>
@@ -223,7 +223,7 @@ function get_user(string $user_name, array $user_arr, array $shares) : string {
                 data-bs-trigger="click focus"
                 data-bs-placement="top"
                 title="Effective Usage is a usage value that augments raw usage by including usage from sibling associations in the hierarchy. It represents how much of the cluster’s capacity effectively appears to have been used by an account or user, after accounting for both their own usage and the usage of their siblings relative to their shares.">
-            <i title="Click here for more information">&#128712;</i>
+            <i title="Click here for more information">&#9432;</i>
         </button>
     </td>
     <td>{$share['effective_usage']}</td>
@@ -238,7 +238,7 @@ function get_user(string $user_name, array $user_arr, array $shares) : string {
                 data-bs-placement="top"
                 data-bs-html="true"
                 title="The Fairshare factor is a floating-point number between 0.0 and 1.0 that SLURM computes to reflect how much of its fair share of cluster resources an account, user, or association has used relative to its entitlement (shares). It might be used by the priority/multifactor scheduling plugin to influence job priorities (depending on the configuration).<ul><li>Closer to 1.0 → Under-served (you have used less than your share) → higher priority</li><li>Closer to 0.0 → Over-served (you have used more than your share) → lower priority</li></ul>">
-            <i title="Click here for more information">&#128712;</i>
+            <i title="Click here for more information">&#9432;</i>
         </button>
     </td>
     <td>{$share['fairshare_factor']}</td>

--- a/view/users.tpl.php
+++ b/view/users.tpl.php
@@ -3,6 +3,7 @@
 namespace view\actions;
 
 use Exception;
+use TemplateLoader;
 
 function get_users(array $users) : string {
     $contents = <<<EOF
@@ -15,7 +16,6 @@ function get_users(array $users) : string {
                 <th>Privileges</th>
                 <th>Full name</th>
                 <th>Department</th>
-                <th>Mail</th>
             </tr>
         </thead>
         <tbody>
@@ -38,11 +38,11 @@ EOF;
 
         if( $deleted ){
             $contents .= '<tr class="deleted-user" title="User was already deleted.">';
-            $contents .=    "<td>" . $user_arr['name'] . " (deleted)</td>";
+            $contents .=    '<td><a href="?action=users&user_name='.$user_arr['name'].'">' . $user_arr['name'] . '</a> (deleted)</td>';
         }
         else {
             $contents .= "<tr>";
-            $contents .=    "<td>" . $user_arr['name'] . "</td>";
+            $contents .=    '<td><a href="?action=users&user_name='.$user_arr['name'].'">' . $user_arr['name'] . '</a></td>';
         }
         $contents .=    "<td><ul>";
         foreach($user_arr['associations'] as $assoc){
@@ -78,7 +78,6 @@ EOF;
                         $contents .= " (" . $ldap_data[$i]["departmentnumber"][0] . ")";
                     }
                     $contents .= "</td>";
-                    $contents .=    "<td>" . $ldap_data[$i]["mail"][0] . "</td>";
 
                     break;
                 }
@@ -95,6 +94,101 @@ EOF;
     </table>
 </div>
 EOF;
+
+    return $contents;
+}
+
+function get_user(string $user_name, array $user_arr, array $shares) : string {
+    $contents = '<a href="?action=users"><button type="button" class="btn btn-secondary">Back to the user table</button></a>';
+
+    $user_name = htmlspecialchars($user_name);
+
+    // Check if user was deleted
+    $deleted = FALSE;
+    if( isset($user_arr['flags']) && is_array($user_arr['flags']))
+        $deleted = in_array("DELETED", $user_arr['flags']);
+    if($deleted)
+        $status = '<span style="color: red">X</span> deleted';
+    else
+        $status = '<span style="color: darkgreen">&#9989;</span> active';
+
+    // Associations
+    $accounts = '';
+    foreach($user_arr['associations'] as $assoc){
+        if($assoc['account'] == $user_arr['default']['account'])
+            $accounts .= '<li><b title="Default account">'
+                         . $assoc['account']
+                         . '</b> (default), cluster ' . $assoc['cluster']
+                         . ' (ID ' . $assoc['id'] . ')</li>';
+        else
+            $accounts .= '<li>' . $assoc['account']
+                          . ', cluster ' . $assoc['cluster']
+                          . ' (ID ' . $assoc['id'] . ')</li>';
+    }
+
+    // Admin privileges
+    if( implode(", ", $user_arr['administrator_level']) == 'None' && in_array($user_arr['name'], config('PRIV_USERS')))
+        $admin_privs =    "<span title='Web administrators have extended permissions in the dashboard but not in SLURM itself.'>&#x1F3E2; Web admin</span>";
+    elseif( implode(", ", $user_arr['administrator_level']) == 'Administrator')
+        $admin_privs =    '<span title="Admin on the whole SLURM cluster.">&#128273; Slurm admin</span>';
+    elseif( implode(", ", $user_arr['administrator_level']) == 'None')
+        $admin_privs =    '<span title="Normal user">-</span>';
+    else
+        $admin_privs =    implode(", ", $user_arr['administrator_level']);
+
+    // retrieve LDAP data
+    $ldap_client = NULL;
+    if(\auth\LDAP::is_supported()){
+        try {
+            $ldap_client = new \auth\LDAP();
+        } catch (Exception $e){
+            addError($e->getMessage());
+        }
+    }
+
+    // LDAP
+    $full_name = '';
+    $department = '';
+    $mail = '';
+    $telephone = '';
+    if (\auth\LDAP::is_supported() && $user_arr['name'] != "root" && $ldap_client !== NULL) {
+        $ldap_data = $ldap_client->get_data_for_user($user_arr['name']);
+        if($ldap_data["count"] === 1){
+            $full_name = $ldap_data[0]["displayname"][0];
+            if(isset($ldap_data[0]["departmentnumber"]) && isset($ldap_data[0]["departmentnumber"][0])){
+                $department .= $ldap_data[0]["departmentnumber"][0];
+            }
+            $mail = '<a href="mailto:' . $ldap_data[0]["mail"][0] . '">' . $ldap_data[0]["mail"][0] . '</a>';
+            $telephone = $ldap_data[0]["telephonenumber"][0] ?? '';
+        }
+    }
+
+    $fairshare_table = '';
+    foreach($shares as $share){
+        $fairshare_table .= '<tr><td colspan="2"><b style="margin-left: 25px">Account <span class="monospaced">' . $share['parent'] . '</span></b></td></tr>';
+        $fairshare_table .= '<tr><td><span style="margin-left: 50px">Raw shares</span></td><td>'.$share['shares'].'</td></tr>';
+        $fairshare_table .= '<tr><td><span style="margin-left: 50px">Normalized shares</span></td><td>'.$share['shares_normalized'].'</td></tr>';
+        $fairshare_table .= '<tr><td><span style="margin-left: 50px">Raw usage</span></td><td>'.$share['usage'].'</td></tr>';
+        $fairshare_table .= '<tr><td><span style="margin-left: 50px">Effective usage</span></td><td>'.$share['effective_usage'].'</td></tr>';
+        $fairshare_table .= '<tr><td><span style="margin-left: 50px">Fairshare factor</span></td><td>'.$share['fairshare_factor'].'</td></tr>';
+    }
+
+    $templateBuilder = new TemplateLoader("userinfo.html");
+    $templateBuilder->setParam("USERNAME", $user_name);
+    $templateBuilder->setParam("FULLNAME", $full_name);
+    $templateBuilder->setParam("DEPARTMENT", $department);
+    $templateBuilder->setParam("MAIL", $mail);
+    $templateBuilder->setParam("TELEPHONE", $telephone);
+
+    $templateBuilder->setParam("STATUS", $status);
+    $templateBuilder->setParam("ACCOUNTS", $accounts);
+    $templateBuilder->setParam("DEFAULT_ACCOUNT", $user_arr['default']['account']);
+    $templateBuilder->setParam("DEFAULT_QOS", $user_arr['default']['qos'] ?? 'N/A');
+    $templateBuilder->setParam("PRIVILEGES", $admin_privs);
+
+    $templateBuilder->setParam("FAIRSHARE", $fairshare_table);
+
+    $contents .= $templateBuilder->build();
 
     return $contents;
 }

--- a/view/users.tpl.php
+++ b/view/users.tpl.php
@@ -169,12 +169,12 @@ function get_user(string $user_name, array $user_arr, array $shares) : string {
         $fairshare_table .=<<<EOF
 <tr>
     <td colspan="2">
-        <b style="margin-left: 25px">Account <span class="monospaced">{$share['parent']}</span></b>
+        <b class="intent-left-level1">Account <span class="monospaced">{$share['parent']}</span></b>
     </td>
 </tr>
 <tr>
     <td>
-        <span style="margin-left: 50px">Raw shares</span>
+        <span class="intent-left-level2">Raw shares</span>
         <button type="button"
                 class="btn p-0"
                 data-bs-toggle="tooltip"
@@ -188,7 +188,7 @@ function get_user(string $user_name, array $user_arr, array $shares) : string {
 </tr>
 <tr>
     <td>
-        <span style="margin-left: 50px">Normalized shares</span>
+        <span class="intent-left-level2">Normalized shares</span>
         <button type="button"
                class="btn p-0"
                data-bs-toggle="tooltip"
@@ -202,7 +202,7 @@ function get_user(string $user_name, array $user_arr, array $shares) : string {
 </tr>
 <tr>
     <td>
-        <span style="margin-left: 50px">Raw usage</span>
+        <span class="intent-left-level2">Raw usage</span>
         <button type="button"
                 class="btn p-0"
                 data-bs-toggle="tooltip"
@@ -216,7 +216,7 @@ function get_user(string $user_name, array $user_arr, array $shares) : string {
 </tr>
 <tr>
     <td>
-        <span style="margin-left: 50px">Effective usage</span>
+        <span class="intent-left-level2">Effective usage</span>
         <button type="button"
                 class="btn p-0"
                 data-bs-toggle="tooltip"
@@ -230,7 +230,7 @@ function get_user(string $user_name, array $user_arr, array $shares) : string {
 </tr>
 <tr>
     <td>
-        <span style="margin-left: 50px">Fairshare factor</span>
+        <span class="intent-left-level2">Fairshare factor</span>
         <button type="button"
                 class="btn p-0"
                 data-bs-toggle="tooltip"
@@ -248,7 +248,7 @@ EOF;
     if(count($shares) == 0){
         $fairshare_table .= <<<EOF
 <tr>
-    <td colspan="2"><i>Currently no data available.</i></td>
+    <td colspan="2" style="text-align: center"><i>Currently no data available.</i></td>
 </tr>
 EOF;
 


### PR DESCRIPTION
# Features and changes
- Add `$with_deleted : bool = FALSE` to `get_user()` in the client
  This allows to query data for deleted users, too.
- Added user detail page to display more information about users.
- Style improvements and new tooltips that work on mobile devices, too.
- Added new client endpoint `get_fairshare()` to get fairshare values.
- Add function `request_plain(string $endpoint, string $namespace, string $api_version, int $ttl = 5)` to the `Request` class that just returns the request body as text.
  This was necessary, because there is a bug in the `v0.0.40` endpoint. It might return `Infinity` (without quotes) in the JSON, but PHP's `json_decode()` does not accept this. This is why we are currently using a dirty bugfix in with `str_replace`.

# Bugfixes
- Bugfix: Error codes were sometimes sent with `http_send_status()`, but this function is actually called `http_response_code()`. Previously, this defaulted to a 500 server error then. This is fixed now.
- Bugfix: Fix wrong call of `RequestFailedException` in `Request` class - could yield to a PHP error (caught as generic 500 server error) instead of a 500 Request error.
- Minor bugfix: change language from `"de"` to `"en"` in HTML tag.
