### PR TITLE
Feature resources per user

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -18,7 +18,7 @@ However, any slurm version `>= 23.11.x` should work. If you encounter any issues
 
 ## Current features
 - Display cluster usage information (state, CPUs, memory, gpus per node).
-- Display cluster usage information (state, CPUs, memory, gpus per node) per node and user. (This feature can be disabled or restricted to privileged users.)
+- Display cluster usage information (CPUs, memory, gpus per node) per node and user. (This feature can be disabled or restricted to privileged users.)
 - Display the current job queue, including a job detail page.
 - Authentication via LDAP or local, and it additionally checks whether the user exists in the accounting database.
 - Communication with `slurmrestd` via unix socket.

--- a/README.MD
+++ b/README.MD
@@ -28,8 +28,8 @@ However, any slurm version `>= 23.11.x` should work. If you encounter any issues
 - Show planned maintenances (`flags=maint`) that were created with e.g. `scontrol create reservation starttime=2024-11-02T13:30:00 duration=5 user=root flags=maint nodes=mynode`.
 - List transitive dependencies for a job.
 - Authentication (at `slurmrestd`) via JWT (optional).
-- Allow administrators to cancel and modify jobs (requires JWT).
-- Allow users to cancel and modify their own jobs (requires JWT).
+- Allow administrators to cancel any jobs (requires JWT).
+- Allow users to cancel their own jobs (requires JWT).
 - Allow users to edit their own jobs and allow admins to edit all jobs (requires JWT).
 - Allow administrators to `DRAIN` or undrain nodes (requires JWT).
 

--- a/README.MD
+++ b/README.MD
@@ -18,7 +18,7 @@ However, any slurm version `>= 23.11.x` should work. If you encounter any issues
 
 ## Current features
 - Display cluster usage information (state, CPUs, memory, gpus per node).
-- Display cluster usage information (CPUs, memory, gpus per node) per node and user. (This feature can be disabled or restricted to privileged users.)
+- Display cluster usage information (CPUs, memory, gpus per node) per node and user. (This feature is disabled per default and can be enabled for all users or for privileged users only.)
 - Display the current job queue, including a job detail page.
 - Authentication via LDAP or local, and it additionally checks whether the user exists in the accounting database.
 - Communication with `slurmrestd` via unix socket.

--- a/README.MD
+++ b/README.MD
@@ -28,8 +28,8 @@ However, any slurm version `>= 23.11.x` should work. If you encounter any issues
 - Show planned maintenances (`flags=maint`) that were created with e.g. `scontrol create reservation starttime=2024-11-02T13:30:00 duration=5 user=root flags=maint nodes=mynode`.
 - List transitive dependencies for a job.
 - Authentication (at `slurmrestd`) via JWT (optional).
-- Allow administrators to requeue / cancel / ... jobs (requires JWT).
-- Allow users to requeue and cancel their own jobs (requires JWT).
+- Allow administrators to cancel and modify jobs (requires JWT).
+- Allow users to cancel and modify their own jobs (requires JWT).
 - Allow users to edit their own jobs and allow admins to edit all jobs (requires JWT).
 - Allow administrators to `DRAIN` or undrain nodes (requires JWT).
 
@@ -178,6 +178,9 @@ However, any slurm version `>= 23.11.x` should work. If you encounter any issues
     
     # Privileged users (OPTIONAL)
     # SetEnv PRIV_USERS        "user1,user2"
+    
+    # Features
+    # SetEnv FEATURE_RESOURCES_PER_USER "disabled" # possible values: disabled,privileged,all
 </VirtualHost>
 ```
 5) Make sure that your apache2 config file is not readable by other users (especially if it contains passwords)!

--- a/README.MD
+++ b/README.MD
@@ -18,6 +18,7 @@ However, any slurm version `>= 23.11.x` should work. If you encounter any issues
 
 ## Current features
 - Display cluster usage information (state, CPUs, memory, gpus per node).
+- Display cluster usage information (state, CPUs, memory, gpus per node) per node and user. (This feature can be disabled or restricted to privileged users.)
 - Display the current job queue, including a job detail page.
 - Authentication via LDAP or local, and it additionally checks whether the user exists in the accounting database.
 - Communication with `slurmrestd` via unix socket.

--- a/client/AbstractClient.inc.php
+++ b/client/AbstractClient.inc.php
@@ -526,6 +526,63 @@ abstract class AbstractClient implements Client {
         }, ARRAY_FILTER_USE_BOTH);
     }
 
+    function get_running_jobs_summary(): array {
+        $json = RequestFactory::newRequest()->request_json("jobs", 'slurm', static::api_version);
+
+        $result = [];
+        foreach ($json['jobs'] as $json_job) {
+            if ( !in_array('RUNNING', $json_job['job_state']) )
+                continue;
+
+            $nodes_str = $this->get_nodes($json_job);
+            if ($nodes_str === '?')
+                continue;
+
+            $cpus_total = isset($json_job['cpus']['set']) && $json_job['cpus']['set']
+                ? (int)$json_job['cpus']['number'] : 0;
+            $node_count = isset($json_job['node_count']['set']) && $json_job['node_count']['set']
+                ? max(1, (int)$json_job['node_count']['number']) : 1;
+            $cpus_per_node = $node_count > 0 ? (int)round($cpus_total / $node_count) : $cpus_total;
+
+            if (isset($json_job['memory_per_node']['set']) && $json_job['memory_per_node']['set']) {
+                $mem_per_node = (int)$json_job['memory_per_node']['number'];
+            }
+            elseif (isset($json_job['memory_per_cpu']['set']) && $json_job['memory_per_cpu']['set']) {
+                $mem_per_node = (int)$json_job['memory_per_cpu']['number'] * max(1, $cpus_per_node);
+            }
+            else {
+                $mem_per_node = 0;
+            }
+
+            $gpus_per_node = 0;
+            // gres_detail is an array with one entry per allocated node; take the first.
+            // Handles both "gpu:2(IDX:0,1)" and "gpu:V100:2(IDX:0,1)" formats.
+            if (isset($json_job['gres_detail']) && is_array($json_job['gres_detail']) && !empty($json_job['gres_detail'])) {
+                $gres_str = $json_job['gres_detail'][0];
+                if (is_string($gres_str) && preg_match('/gpu.*?:(\d+)(?:\(|,|$)/i', $gres_str, $matches)) {
+                    $gpus_per_node = (int)$matches[1];
+                }
+            }
+            // Fallback: parse total from tres_alloc_str ("...gres/gpu=2...") and split evenly across nodes.
+            if ($gpus_per_node === 0 && isset($json_job['tres_alloc_str']) && is_string($json_job['tres_alloc_str'])) {
+                if (preg_match('/gres\/gpu=(\d+)/', $json_job['tres_alloc_str'], $matches)) {
+                    $gpus_total = (int)$matches[1];
+                    $gpus_per_node = $node_count > 0 ? (int)round($gpus_total / $node_count) : $gpus_total;
+                }
+            }
+
+            $result[] = [
+                'user_name'     => $json_job['user_name'],
+                'partition'     => $json_job['partition'] ?? '',
+                'nodes_str'     => $nodes_str,
+                'cpus_per_node' => $cpus_per_node,
+                'mem_per_node'  => $mem_per_node,
+                'gpus_per_node' => $gpus_per_node,
+            ];
+        }
+        return $result;
+    }
+
     protected function _slurm_queue_order_by(array $jobs, string $orderby) : array {
         if( !in_array($orderby, array('job_id', 'user_name', 'priority', 'time_start')))
             return $jobs;

--- a/client/Client.inc.php
+++ b/client/Client.inc.php
@@ -220,6 +220,15 @@ interface Client{
     function update_job(array $job_data) : bool;
 
     function set_node_state(string $nodename, string $new_state) : bool;
+
+    /**
+     * Returns a summary of all currently running jobs.
+     * Used to build the per-node, per-user resource breakdown on the cluster usage page.
+     * @return array Array of running jobs, each with keys:
+     *   user_name (string), nodes_str (string), cpus_per_node (int),
+     *   mem_per_node (int, MiB), gpus_per_node (int)
+     */
+    function get_running_jobs_summary(): array;
 }
 
 class ClientFactory {

--- a/globals.inc.php
+++ b/globals.inc.php
@@ -128,6 +128,13 @@ $config = [
     // ------------------------------------------------------------------
 
     /**
+     * Show p_low partition jobs as a separate striped segment in the cluster-wide overview bars.
+     * Requires an additional API call to /slurm/jobs; disabled by default.
+     * Set env var FEATURE_P_LOW_IN_CLUSTER_OVERVIEW=enabled to enable.
+     */
+    'feature_p_low_in_cluster_overview' => cfg_env('FEATURE_P_LOW_IN_CLUSTER_OVERVIEW', 'disabled') === 'enabled',
+
+    /**
      * Show a per-user CPU/RAM/GPU breakdown with stacked progress bars on the cluster usage page.
      * Requires an additional API call to /slurm/jobs; disabled by default.
      * Set env var FEATURE_RESOURCES_PER_USER=all or FEATURE_RESOURCES_PER_USER=privileged to enable.

--- a/globals.inc.php
+++ b/globals.inc.php
@@ -121,7 +121,18 @@ $config = [
      */
     'SLURM_USER' => cfg_env('SLURM_USER', 'slurm'),
 
-    'PRIV_USERS' => explode(',', getenv('PRIV_USERS') ?: '')
+    'PRIV_USERS' => explode(',', getenv('PRIV_USERS') ?: ''),
+
+    // ------------------------------------------------------------------
+    // FEATURE FLAGS
+    // ------------------------------------------------------------------
+
+    /**
+     * Show a per-user CPU/RAM/GPU breakdown with stacked progress bars on the cluster usage page.
+     * Requires an additional API call to /slurm/jobs; disabled by default.
+     * Set env var FEATURE_RESOURCES_PER_USER=true to enable.
+     */
+    'feature_resources_per_user' => filter_var(cfg_env('FEATURE_RESOURCES_PER_USER', 'false'), FILTER_VALIDATE_BOOLEAN),
 ];
 
 function config($key = null) {

--- a/globals.inc.php
+++ b/globals.inc.php
@@ -130,9 +130,15 @@ $config = [
     /**
      * Show a per-user CPU/RAM/GPU breakdown with stacked progress bars on the cluster usage page.
      * Requires an additional API call to /slurm/jobs; disabled by default.
-     * Set env var FEATURE_RESOURCES_PER_USER=true to enable.
+     * Set env var FEATURE_RESOURCES_PER_USER=all or FEATURE_RESOURCES_PER_USER=privileged to enable.
      */
-    'feature_resources_per_user' => filter_var(cfg_env('FEATURE_RESOURCES_PER_USER', 'false'), FILTER_VALIDATE_BOOLEAN),
+    'feature_resources_per_user' => in_array(
+        cfg_env('FEATURE_RESOURCES_PER_USER', 'disabled'),
+        ['disabled', 'all', 'privileged'],
+        true
+    )
+        ? cfg_env('FEATURE_RESOURCES_PER_USER', 'disabled')
+        : 'disabled',
 ];
 
 function config($key = null) {

--- a/public/index.php
+++ b/public/index.php
@@ -109,8 +109,11 @@ if( isset($_SESSION['USER']) ){
 
         case "usage":
             $title = 'Cluster usage';
-            $contents .= "<h2>Current cluster usage</h2>";
-            $contents .= \view\actions\get_all_nodes_usage($dao);
+            $contents .= \view\actions\get_all_nodes_usage(
+                    $dao,
+                    $csp_nonce,
+                    isset($_GET['show_users']) && $_GET['show_users'] === '1'
+            );
             break;
 
         case "job":
@@ -488,8 +491,11 @@ if( isset($_SESSION['USER']) ){
             apcu_delete("slurm/node/".$nodename); // Delete cached entry because we KNOW that it has changed.
 
             $title = 'Cluster usage';
-            $contents .= "<h2>Current cluster usage</h2>";
-            $contents .= \view\actions\get_all_nodes_usage($dao);
+            $contents .= \view\actions\get_all_nodes_usage(
+                    $dao,
+                    $csp_nonce,
+                    isset($_GET['show_users']) && $_GET['show_users'] === '1'
+            );
             break;
 
         default:

--- a/public/index.php
+++ b/public/index.php
@@ -110,9 +110,7 @@ if( isset($_SESSION['USER']) ){
         case "usage":
             $title = 'Cluster usage';
             $contents .= "<h2>Current cluster usage</h2>";
-            foreach ($dao->getNodeList() as $node) {
-                $contents .= \view\actions\get_usage($dao->get_node_info($node));
-            }
+            $contents .= \view\actions\get_all_nodes_usage($dao);
             break;
 
         case "job":
@@ -491,9 +489,7 @@ if( isset($_SESSION['USER']) ){
 
             $title = 'Cluster usage';
             $contents .= "<h2>Current cluster usage</h2>";
-            foreach ($dao->getNodeList() as $node) {
-                $contents .= \view\actions\get_usage($dao->get_node_info($node));
-            }
+            $contents .= \view\actions\get_all_nodes_usage($dao);
             break;
 
         default:

--- a/templates/nodeinfo.html
+++ b/templates/nodeinfo.html
@@ -107,6 +107,7 @@
                 {{GPU_USED}} of {{GPU_TOTAL}} GPUs in use ({{GPU_PERCENTAGE}} %)
             </td>
         </tr>
+        {{USER_RESOURCE_BREAKDOWN}}
     </table>
 </div>
 

--- a/templates/nodeinfo.html
+++ b/templates/nodeinfo.html
@@ -107,7 +107,6 @@
                 {{GPU_USED}} of {{GPU_TOTAL}} GPUs in use ({{GPU_PERCENTAGE}} %)
             </td>
         </tr>
-        {{USER_RESOURCE_BREAKDOWN}}
     </table>
 </div>
 
@@ -119,7 +118,11 @@
     <div class="card card-body">
         <div class="table-responsive">
             <table class="nodeinfo table">
+                {{USER_RESOURCE_BREAKDOWN}}
 
+                <tr>
+                    <td colspan="2"><strong>Information about the node</strong></td>
+                </tr>
                 <tr>
                     <td>Architecture:</td>
                     <td>{{ARCHITECTURE}}</td>

--- a/templates/nodeinfo.html
+++ b/templates/nodeinfo.html
@@ -19,8 +19,7 @@
                     <span class="visually-hidden">Toggle Dropdown</span>
                 </button>
                 <ul class="dropdown-menu">
-                    <li><a class="dropdown-item" href="?action=node-set-state&nodename={{NODENAME}}&state=resume">Resume node</a></li>
-                    <li><a class="dropdown-item" href="?action=node-set-state&nodename={{NODENAME}}&state=drain">Drain node</a></li>
+                    {{NODE_STATE_ACTIONS}}
                 </ul>
             </td>
         </tr>
@@ -110,9 +109,14 @@
     </table>
 </div>
 
-<button class="btn btn-primary" type="button" data-bs-toggle="collapse" data-bs-target="#collapse{{NODENAME}}" aria-expanded="false" aria-controls="collapse{{NODENAME}}">
-    Show/Hide more
-</button>
+<div class="d-flex gap-2 align-items-center">
+    <button class="btn btn-primary" type="button" data-bs-toggle="collapse" data-bs-target="#collapse{{NODENAME}},#collapseToggle{{NODENAME}}" aria-expanded="false" aria-controls="collapse{{NODENAME}}">
+        Show/Hide more
+    </button>
+    <div class="collapse" id="collapseToggle{{NODENAME}}">
+        {{SHOW_USERS_TOGGLE}}
+    </div>
+</div>
 
 <div class="collapse" id="collapse{{NODENAME}}">
     <div class="card card-body">

--- a/utils.inc.php
+++ b/utils.inc.php
@@ -108,3 +108,50 @@ function is_valid_username(string $username): bool {
     $pattern = '/^[a-z_]([a-z0-9_-]{0,31}|[a-z0-9_-]{0,30}\\$)$/';
     return preg_match($pattern, $username) === 1;
 }
+
+/**
+ * Checks whether a node name is contained in a Slurm nodelist string.
+ * Handles comma-separated lists and bracket range notation (e.g. node[01-05,08]).
+ */
+function node_is_in_nodelist(string $node, string $nodelist): bool {
+    if ($nodelist === '' || $nodelist === '?') return false;
+    if ($node === $nodelist) return true;
+
+    foreach (_split_nodelist($nodelist) as $part) {
+        if (preg_match('/^(.+?)\[(.+)\]$/', $part, $m)) {
+            $prefix = $m[1];
+            if (!str_starts_with($node, $prefix)) continue;
+            $suffix = substr($node, strlen($prefix));
+            foreach (explode(',', $m[2]) as $range) {
+                if (str_contains($range, '-')) {
+                    [$lo, $hi] = explode('-', $range, 2);
+                    if ((int)$suffix >= (int)$lo && (int)$suffix <= (int)$hi) return true;
+                } elseif ($range === $suffix) {
+                    return true;
+                }
+            }
+        } elseif ($part === $node) {
+            return true;
+        }
+    }
+    return false;
+}
+
+/** Splits a Slurm nodelist on top-level commas (skipping commas inside brackets). */
+function _split_nodelist(string $nodelist): array {
+    $parts = [];
+    $depth = 0;
+    $current = '';
+    for ($i = 0, $len = strlen($nodelist); $i < $len; $i++) {
+        $c = $nodelist[$i];
+        if ($c === '[') $depth++;
+        elseif ($c === ']') $depth--;
+        elseif ($c === ',' && $depth === 0) {
+            if ($current !== '') { $parts[] = $current; $current = ''; }
+            continue;
+        }
+        $current .= $c;
+    }
+    if ($current !== '') $parts[] = $current;
+    return $parts;
+}

--- a/view/usage.tpl.php
+++ b/view/usage.tpl.php
@@ -55,21 +55,48 @@ function _build_node_user_breakdown(array $running_jobs, string $node): array {
 }
 
 /**
+ * Converts HSL (h: 0–359, s/l: 0–1) to [R, G, B] each 0–255.
+ */
+function _hsl_to_rgb(int $h, float $s, float $l): array {
+    $c = (1 - abs(2 * $l - 1)) * $s;
+    $x = $c * (1 - abs(fmod($h / 60.0, 2) - 1));
+    $m = $l - $c / 2;
+    if( $h < 60 )
+        [$r, $g, $b] = [$c, $x, 0];
+    elseif( $h < 120 )
+        [$r, $g, $b] = [$x, $c, 0];
+    elseif( $h < 180 )
+        [$r, $g, $b] = [0,  $c, $x];
+    elseif( $h < 240 )
+        [$r, $g, $b] = [0,  $x, $c];
+    elseif( $h < 300 )
+        [$r, $g, $b] = [$x, 0,  $c];
+    else
+        [$r, $g, $b] = [$c, 0,  $x];
+    return [(int)round(($r+$m)*255), (int)round(($g+$m)*255), (int)round(($b+$m)*255)];
+}
+
+/**
+ * Returns a stable {hex background, CSS text color} for a username.
+ * Hue is derived from the md5 hash; saturation/lightness are fixed for vibrant,
+ * readable colors. Text color is chosen via WCAG relative-luminance threshold.
+ */
+function _user_color(string $user): array {
+    $hue = hexdec(substr(md5($user), 0, 4)) % 360;
+    [$r, $g, $b] = _hsl_to_rgb($hue, 0.65, 0.45);
+    $hex = sprintf('#%02x%02x%02x', $r, $g, $b);
+    $luminance = 0.2126 * ($r / 255) + 0.7152 * ($g / 255) + 0.0722 * ($b / 255);
+    return ['hex' => $hex, 'text' => ($luminance > 0.22 ? '#222' : '#fff')];
+}
+
+/**
  * Renders the per-user resource breakdown as table rows with stacked progress bars.
  * p_low partition jobs are shown as gray striped segments and listed separately.
- * @return string an empty string when no jobs are running on the node, the usage data as HTML otherwise
+ * Returns an empty string when no jobs are running on the node.
  */
 function _render_user_breakdown(array $user_breakdown, int $cpu_total, int $mem_total, int $gpu_total): string {
     if (empty($user_breakdown))
         return '';
-
-    // Bootstrap background/text color pairs (index-stable)
-    $bg_colors   = ['primary', 'success', 'danger', 'warning', 'info', 'secondary', 'dark'];
-    $text_colors = ['text-white', 'text-white', 'text-white', 'text-dark', 'text-dark', 'text-white', 'text-white'];
-
-    $color_idx = function(string $user) use ($bg_colors): int {
-        return abs(crc32($user)) % count($bg_colors);
-    };
 
     // Check totals across both regular and p_low resources
     $has_mem  = $mem_total > 0 && (
@@ -104,16 +131,16 @@ function _render_user_breakdown(array $user_breakdown, int $cpu_total, int $mem_
 
         // Regular (colored) segments — one per individual job, with a white divider between jobs
         foreach ($user_breakdown as $user => $res) {
-            $idx = $color_idx($user);
+            $color  = _user_color($user);
             $user_e = htmlspecialchars($user, ENT_QUOTES, 'UTF-8');
             foreach ($res['jobs'] as $job) {
                 $val = $job[$res_def['key']] ?? 0;
-                if ($val <= 0) continue;
-                $pct = min(100.0, round($val / $total * 100, 1));
+                if ($val <= 0)
+                    continue;
+                $pct     = min(100.0, round($val / $total * 100, 1));
                 $tooltip = $user_e . ': ' . $val . $res_def['suffix'] . ' (' . $pct . '%)';
-                $html .= '<div class="progress-bar bg-' . $bg_colors[$idx] . ' ' . $text_colors[$idx] . '"'
-                       . ' role="progressbar"'
-                       . ' style="width:' . $pct . '%;border-right:2px solid rgba(255,255,255,0.55)"'
+                $html .= '<div class="progress-bar" role="progressbar"'
+                       . ' style="width:' . $pct . '%;background-color:' . $color['hex'] . ';color:' . $color['text'] . ';border-right:2px solid rgba(255,255,255,0.55)"'
                        . ' data-bs-toggle="tooltip" data-bs-trigger="hover focus"'
                        . ' title="' . htmlspecialchars($tooltip, ENT_QUOTES, 'UTF-8') . '">'
                        . ($pct >= 12 ? $user_e : '') . '</div>';
@@ -125,11 +152,11 @@ function _render_user_breakdown(array $user_breakdown, int $cpu_total, int $mem_
             $user_e = htmlspecialchars($user, ENT_QUOTES, 'UTF-8');
             foreach ($res['jobs_pl'] as $job) {
                 $val = $job[$res_def['key']] ?? 0;
-                if ($val <= 0) continue;
-                $pct = min(100.0, round($val / $total * 100, 1));
+                if ($val <= 0)
+                    continue;
+                $pct     = min(100.0, round($val / $total * 100, 1));
                 $tooltip = $user_e . ' (p_low): ' . $val . $res_def['suffix'] . ' (' . $pct . '%)';
-                $html .= '<div class="progress-bar progress-bar-striped bg-secondary"'
-                       . ' role="progressbar"'
+                $html .= '<div class="progress-bar progress-bar-striped bg-secondary" role="progressbar"'
                        . ' style="width:' . $pct . '%;border-right:2px solid rgba(255,255,255,0.55)"'
                        . ' data-bs-toggle="tooltip" data-bs-trigger="hover focus"'
                        . ' title="' . htmlspecialchars($tooltip, ENT_QUOTES, 'UTF-8') . '">'
@@ -140,17 +167,13 @@ function _render_user_breakdown(array $user_breakdown, int $cpu_total, int $mem_
         $html .= '</div></td></tr>';
     }
 
-    // Legend row
-    $html .= '<tr><td style="font-size:0.85em;white-space:nowrap">Normal jobs:</td><td>';
-
-    // Regular badges
+    // Regular-jobs legend row
     $regular_badges = '';
     foreach ($user_breakdown as $user => $res) {
-        $has_regular = ($res['cpus'] ?? 0) > 0 || ($res['mem'] ?? 0) > 0 || ($res['gpus'] ?? 0) > 0;
-        if ( !$has_regular )
+        if (($res['cpus'] ?? 0) <= 0 && ($res['mem'] ?? 0) <= 0 && ($res['gpus'] ?? 0) <= 0)
             continue;
+        $color  = _user_color($user);
         $user_e = htmlspecialchars($user, ENT_QUOTES, 'UTF-8');
-        $idx = $color_idx($user);
         $details = [];
         if (($res['cpus'] ?? 0) > 0)
             $details[] = $res['cpus'] . ' CPUs';
@@ -158,21 +181,21 @@ function _render_user_breakdown(array $user_breakdown, int $cpu_total, int $mem_
             $details[] = $res['mem']  . ' MiB';
         if (($res['gpus'] ?? 0) > 0 && $has_gpu)
             $details[] = $res['gpus'] . ' GPUs';
-        $detail_str = implode(', ', $details);
-        $regular_badges .= '<span class="badge bg-' . $bg_colors[$idx] . ' ' . $text_colors[$idx] . '">'
-                         . '<a href="?action=users&user_name=' . $user_e . '" class="' . $text_colors[$idx] . '" style="text-decoration:none">' . $user_e . '</a>'
-                         . (empty($detail_str) ? '' : ': ' . htmlspecialchars($detail_str, ENT_QUOTES, 'UTF-8'))
+        $regular_badges .= '<span class="badge" style="background-color:' . $color['hex'] . ';color:' . $color['text'] . '">'
+                         . '<a href="?action=users&user_name=' . $user_e . '" style="color:' . $color['text'] . ';text-decoration:none">' . $user_e . '</a>'
+                         . (empty($details) ? '' : ': ' . htmlspecialchars(implode(', ', $details), ENT_QUOTES, 'UTF-8'))
                          . '</span>';
     }
+    $html .= '<tr><td style="font-size:0.85em;white-space:nowrap">Normal jobs:</td>'
+           . '<td><div style="display:flex;flex-wrap:wrap;gap:4px">' . $regular_badges . '</div></td></tr>';
 
-    // p_low badges (only if any p_low jobs exist)
-    $plow_badges = '';
+    // p_low-jobs legend row (only when p_low jobs exist)
     if ($has_plow) {
+        $plow_badges = '';
         foreach ($user_breakdown as $user => $res) {
-            $has_pl = ($res['cpus_pl'] ?? 0) > 0 || ($res['mem_pl'] ?? 0) > 0 || ($res['gpus_pl'] ?? 0) > 0;
-            if (!$has_pl)
+            if (($res['cpus_pl'] ?? 0) <= 0 && ($res['mem_pl'] ?? 0) <= 0 && ($res['gpus_pl'] ?? 0) <= 0)
                 continue;
-            $user_e = htmlspecialchars($user, ENT_QUOTES, 'UTF-8');
+            $user_e  = htmlspecialchars($user, ENT_QUOTES, 'UTF-8');
             $details = [];
             if (($res['cpus_pl'] ?? 0) > 0)
                 $details[] = $res['cpus_pl'] . ' CPUs';
@@ -180,19 +203,11 @@ function _render_user_breakdown(array $user_breakdown, int $cpu_total, int $mem_
                 $details[] = $res['mem_pl']  . ' MiB';
             if (($res['gpus_pl'] ?? 0) > 0 && $has_gpu)
                 $details[] = $res['gpus_pl'] . ' GPUs';
-            $detail_str = implode(', ', $details);
-            $plow_badges .= '<span class="badge bg-secondary progress-bar-striped text-white"'
-                          . ' style="background-size:1rem 1rem">'
+            $plow_badges .= '<span class="badge bg-secondary progress-bar-striped text-white" style="background-size:1rem 1rem">'
                           . '<a href="?action=users&user_name=' . $user_e . '" class="text-white" style="text-decoration:none">' . $user_e . '</a>'
-                          . (empty($detail_str) ? '' : ': ' . htmlspecialchars($detail_str, ENT_QUOTES, 'UTF-8'))
+                          . (empty($details) ? '' : ': ' . htmlspecialchars(implode(', ', $details), ENT_QUOTES, 'UTF-8'))
                           . '</span>';
         }
-    }
-
-    $html .= '<div style="display:flex;flex-wrap:wrap;gap:4px">' . $regular_badges . '</div>';
-    $html .= '</td></tr>';
-
-    if (!empty($plow_badges)) {
         $html .= '<tr><td style="font-size:0.85em;white-space:nowrap">p_low jobs:</td>'
                . '<td><div style="display:flex;flex-wrap:wrap;gap:4px">' . $plow_badges . '</div></td></tr>';
     }

--- a/view/usage.tpl.php
+++ b/view/usage.tpl.php
@@ -11,7 +11,15 @@ use TemplateLoader;
  */
 function get_all_nodes_usage(\client\Client $dao): string {
     $contents = '';
-    $running_jobs = config('feature_resources_per_user') ? $dao->get_running_jobs_summary() : [];
+
+    if(
+        config('feature_resources_per_user') === 'all' ||
+        config('feature_resources_per_user') === 'privileged' && \auth\current_user_is_privileged()
+    )
+        $running_jobs = $dao->get_running_jobs_summary();
+    else
+        $running_jobs = [];
+
     foreach ($dao->getNodeList() as $node) {
         $contents .= get_usage(
             $dao->get_node_info($node),

--- a/view/usage.tpl.php
+++ b/view/usage.tpl.php
@@ -146,7 +146,8 @@ function _render_user_breakdown(array $user_breakdown, int $cpu_total, int $mem_
                 if ($val <= 0)
                     continue;
                 $pct     = min(100.0, round($val / $total * 100, 1));
-                $tooltip = $user_e . ': ' . $val . $res_def['suffix'] . ' (' . $pct . '%)';
+                $val_f = number_format($val, 0, '.', ',');
+                $tooltip = $user_e . ': ' . $val_f . $res_def['suffix'] . ' (' . $pct . '%)';
                 $html .= '<div class="progress-bar" role="progressbar"'
                        . ' style="width:' . $pct . '%;background-color:' . $color['hex'] . ';color:' . $color['text'] . ';border-right:2px solid rgba(255,255,255,0.55)"'
                        . ' data-bs-toggle="tooltip" data-bs-trigger="hover focus"'
@@ -163,7 +164,8 @@ function _render_user_breakdown(array $user_breakdown, int $cpu_total, int $mem_
                 if ($val <= 0)
                     continue;
                 $pct     = min(100.0, round($val / $total * 100, 1));
-                $tooltip = $user_e . ' (p_low): ' . $val . $res_def['suffix'] . ' (' . $pct . '%)';
+                $val_f = number_format($val, 0, '.', ',');
+                $tooltip = $user_e . ' (p_low): ' . $val_f . $res_def['suffix'] . ' (' . $pct . '%)';
                 $html .= '<div class="progress-bar progress-bar-striped bg-secondary" role="progressbar"'
                        . ' style="width:' . $pct . '%;border-right:2px solid rgba(255,255,255,0.55)"'
                        . ' data-bs-toggle="tooltip" data-bs-trigger="hover focus"'
@@ -184,11 +186,11 @@ function _render_user_breakdown(array $user_breakdown, int $cpu_total, int $mem_
         $user_e = htmlspecialchars($user, ENT_QUOTES, 'UTF-8');
         $details = [];
         if (($res['cpus'] ?? 0) > 0)
-            $details[] = $res['cpus'] . ' CPUs';
+            $details[] = number_format($res['cpus'], 0, '.', ',') . ' CPUs';
         if (($res['mem']  ?? 0) > 0 && $has_mem)
-            $details[] = $res['mem']  . ' MiB';
+            $details[] =  number_format($res['mem'], 0, '.', ',') . ' MiB';
         if (($res['gpus'] ?? 0) > 0 && $has_gpu)
-            $details[] = $res['gpus'] . ' GPUs';
+            $details[] = number_format($res['gpus'], 0, '.', ',') . ' GPUs';
         $regular_badges .= '<span class="badge" style="background-color:' . $color['hex'] . ';color:' . $color['text'] . '">'
                          . '<a href="?action=users&user_name=' . $user_e . '" style="color:' . $color['text'] . ';text-decoration:none">' . $user_e . '</a>'
                          . (empty($details) ? '' : ': ' . htmlspecialchars(implode(', ', $details), ENT_QUOTES, 'UTF-8'))
@@ -206,11 +208,11 @@ function _render_user_breakdown(array $user_breakdown, int $cpu_total, int $mem_
             $user_e  = htmlspecialchars($user, ENT_QUOTES, 'UTF-8');
             $details = [];
             if (($res['cpus_pl'] ?? 0) > 0)
-                $details[] = $res['cpus_pl'] . ' CPUs';
+                $details[] = number_format($res['cpus_pl'], 0, '.', ',') . ' CPUs';
             if (($res['mem_pl']  ?? 0) > 0 && $has_mem)
-                $details[] = $res['mem_pl']  . ' MiB';
+                $details[] =  number_format($res['mem_pl'], 0, '.', ',') . ' MiB';
             if (($res['gpus_pl'] ?? 0) > 0 && $has_gpu)
-                $details[] = $res['gpus_pl'] . ' GPUs';
+                $details[] = number_format($res['gpus_pl'], 0, '.', ',') . ' GPUs';
             $plow_badges .= '<span class="badge bg-secondary progress-bar-striped text-white" style="background-size:1rem 1rem">'
                           . '<a href="?action=users&user_name=' . $user_e . '" class="text-white" style="text-decoration:none">' . $user_e . '</a>'
                           . (empty($details) ? '' : ': ' . htmlspecialchars(implode(', ', $details), ENT_QUOTES, 'UTF-8'))
@@ -238,10 +240,10 @@ function get_usage(array $data, array $user_breakdown = []) : string {
     // Thus, mem_total-mem_free can be negative if and only if in slurm.conf the node does not have the
     // full RAM memory for RealMemory=. In order to avoid confusions, we set the minimum to 0.
     $templateBuilder->setParam("MEM_PERCENTAGE", number_format($data["mem_total"] > 0 ? max(0, ($data["mem_total"]-$data["mem_free"])/$data["mem_total"]*100) : 0, 2));
-    $templateBuilder->setParam("MEM_USED", max(0,$data["mem_total"] - $data["mem_free"]));
-    $templateBuilder->setParam("MEM_TOTAL", $data["mem_total"]);
+    $templateBuilder->setParam("MEM_USED", number_format(max(0,$data["mem_total"] - $data["mem_free"]), 0, '.', ','));
+    $templateBuilder->setParam("MEM_TOTAL", number_format($data["mem_total"], 0, '.', ','));
     $templateBuilder->setParam("ALLOC_MEM_PERCENTAGE", number_format($data["mem_total"] > 0 ? $data["mem_alloc"]/$data["mem_total"]*100 : 0, 2));
-    $templateBuilder->setParam("ALLOC_MEM", $data["mem_alloc"]);
+    $templateBuilder->setParam("ALLOC_MEM", number_format($data["mem_alloc"], 0, '.', ','));
 
     $gres = $data["gres"];
     $gres_used = $data["gres_used"];

--- a/view/usage.tpl.php
+++ b/view/usage.tpl.php
@@ -7,37 +7,142 @@ use TemplateLoader;
  * Renders the full cluster-usage section including all nodes.
  * Fetches running-job summaries once and distributes them per node.
  * @param \client\Client $dao Client to query the data.
+ * @param string $nonce JS nonce that allows to execute JavaScript
+ * @param bool $show_users_requested whether the cluster usage view should show individual user's usage or not
  * @return string The usage data as HTML string.
  */
-function get_all_nodes_usage(\client\Client $dao): string {
-    $contents = '';
+function get_all_nodes_usage(\client\Client $dao, string $nonce = '', bool $show_users_requested = FALSE): string {
+    $feature = config('feature_resources_per_user');
+    $can_show_users = ($feature === 'all') || ($feature === 'privileged' && \auth\current_user_is_privileged());
 
-    if(
-        config('feature_resources_per_user') === 'all' ||
-        config('feature_resources_per_user') === 'privileged' && \auth\current_user_is_privileged()
-    )
-        $running_jobs = $dao->get_running_jobs_summary();
-    else
-        $running_jobs = [];
+    $show_plow_overview = (config('feature_p_low_in_cluster_overview') === TRUE);
+
+    // Fetch jobs when the per-user view is active OR the p_low overview feature needs it
+    $need_jobs    = ($can_show_users && $show_users_requested) || $show_plow_overview;
+    $running_jobs = $need_jobs ? $dao->get_running_jobs_summary() : [];
+
+    $cluster_totals = [
+        'cpus' => 0, 'cpus_alloc' => 0,
+        'mem_total' => 0, 'mem_alloc' => 0,
+        'gpus_total' => 0, 'gpus_used' => 0,
+        'cpus_unusable' => 0, 'mem_unusable' => 0, 'gpus_unusable' => 0,
+        'cpus_plow' => 0, 'mem_plow' => 0, 'gpus_plow' => 0,
+    ];
+    $cluster_user_breakdown = [];
+    $node_infos = [];
 
     foreach ($dao->getNodeList() as $node) {
-        $contents .= get_usage(
-            $dao->get_node_info($node),
-            $running_jobs ? _build_node_user_breakdown($running_jobs, $node) : []
-        );
+        $node_data    = $dao->get_node_info($node);
+        $user_bkd = $running_jobs ? _build_node_user_breakdown($running_jobs, $node) : [];
+
+        $cpu_total = (int)$node_data['cpus'];
+        $cpu_alloc = (int)$node_data['alloc_cpus'];
+        $mem_total = (int)$node_data['mem_total'];
+        $mem_alloc = (int)$node_data['mem_alloc'];
+        $gres      = $node_data['gres'];
+        $gres_used = $node_data['gres_used'];
+        if ($gres !== '') {
+            $gpu_total = (int)preg_replace('/.*:(\d+)(?:\(.*\))?$/', '$1', $gres);
+            $gpu_used  = (int)preg_replace('/.*:(\d+)(?:\(.*\))?$/', '$1', $gres_used);
+        } else {
+            $gpu_total = 0;
+            $gpu_used  = 0;
+        }
+
+        $cluster_totals['cpus']      += $cpu_total;
+        $cluster_totals['mem_total'] += $mem_total;
+        $cluster_totals['gpus_total']+= $gpu_total;
+
+        // Derive per-node job totals from the user breakdown (job API).
+        // Use the maximum of node-API and job-API values: in some SLURM configurations
+        // alloc_cpus/alloc_memory from the node endpoint may lag or return 0 while
+        // the jobs endpoint already reports running allocations.
+        $job_node_cpus = 0;
+        $job_node_mem  = 0;
+        $job_node_gpus = 0;
+        foreach ($user_bkd as $res) {
+            $job_node_cpus += ($res['cpus'] ?? 0) + ($res['cpus_pl'] ?? 0);
+            $job_node_mem  += ($res['mem']  ?? 0) + ($res['mem_pl']  ?? 0);
+            $job_node_gpus += ($res['gpus'] ?? 0) + ($res['gpus_pl'] ?? 0);
+        }
+        $cpu_alloc_eff = max($cpu_alloc, $job_node_cpus);
+        $mem_alloc_eff = max($mem_alloc, $job_node_mem);
+        $gpu_used_eff  = max($gpu_used,  $job_node_gpus);
+
+        $cluster_totals['cpus_alloc'] += $cpu_alloc_eff;
+        $cluster_totals['mem_alloc']  += $mem_alloc_eff;
+        $cluster_totals['gpus_used']  += $gpu_used_eff;
+
+        // A node is blocked when CPUs or memory are fully allocated - no new job can start there.
+        if (
+            ($cpu_total > 0 && $cpu_alloc_eff >= $cpu_total) ||
+            ($mem_total > 0 && $mem_alloc_eff >= $mem_total)
+        ) {
+            $cluster_totals['cpus_unusable'] += max(0, $cpu_total - $cpu_alloc_eff);
+            $cluster_totals['mem_unusable']  += max(0, $mem_total - $mem_alloc_eff);
+            $cluster_totals['gpus_unusable'] += max(0, $gpu_total - $gpu_used_eff);
+        }
+
+        // p_low cluster totals (always when jobs data is available, for the overview bar)
+        foreach ($user_bkd as $res) {
+            $cluster_totals['cpus_plow'] += ($res['cpus_pl'] ?? 0);
+            $cluster_totals['mem_plow']  += ($res['mem_pl']  ?? 0);
+            $cluster_totals['gpus_plow'] += ($res['gpus_pl'] ?? 0);
+        }
+
+        // Per-user breakdown only when the user explicitly requested it
+        if ($show_users_requested) {
+            foreach ($user_bkd as $user => $res) {
+                if ( ! isset($cluster_user_breakdown[$user]) ){
+                    $cluster_user_breakdown[$user] = ['cpus' => 0, 'mem' => 0, 'gpus' => 0,
+                                                      'cpus_pl' => 0, 'mem_pl' => 0, 'gpus_pl' => 0];
+                }
+                foreach (['cpus', 'mem', 'gpus', 'cpus_pl', 'mem_pl', 'gpus_pl'] as $k) {
+                    $cluster_user_breakdown[$user][$k] += (int)($res[$k] ?? 0);
+                }
+            }
+        }
+
+        // Only expose per-user data in the node card when requested
+        $node_infos[] = [$node_data, $show_users_requested ? $user_bkd : []];
     }
+    ksort($cluster_user_breakdown);
+
+    $contents = _render_cluster_summary(
+        $cluster_totals,
+        $cluster_user_breakdown,
+        $can_show_users && $show_users_requested,
+        $nonce,
+        $can_show_users,
+        $show_plow_overview
+    );
+
+    // Node-level toggle — must navigate to the exact same URLs as the cluster summary checkbox
+    if ($can_show_users) {
+        $node_toggle = $show_users_requested
+            ? '<a href="?action=usage" class="btn btn-sm btn-outline-secondary">Hide users</a>'
+            : '<a href="?action=usage&show_users=1" class="btn btn-sm btn-outline-secondary">Show users</a>';
+    } else {
+        $node_toggle = '';
+    }
+
+    foreach ($node_infos as [$node_data, $user_bkd])
+        $contents .= get_usage($node_data, $user_bkd, $node_toggle);
+
     return $contents;
 }
 
 /**
  * Groups running-job summaries by user for a single node. p_low resources tracked separately via _pl suffix.
- * @param array $running_jobs Array of running jobs, as returns by \\Client\\get_running_jobs_summary
+ * @param array $running_jobs Array of running jobs, as returned by \\Client\\get_running_jobs_summary
  * @param string $node Node name.
  */
 function _build_node_user_breakdown(array $running_jobs, string $node): array {
     $breakdown = [];
     foreach ($running_jobs as $job) {
-        if (!\utils\node_is_in_nodelist($node, $job['nodes_str'])) continue;
+        if ( ! \utils\node_is_in_nodelist($node, $job['nodes_str']) )
+            continue;
+
         $user = $job['user_name'];
         if (!isset($breakdown[$user])) {
             $breakdown[$user] = ['cpus' => 0, 'mem' => 0, 'gpus' => 0,
@@ -45,8 +150,7 @@ function _build_node_user_breakdown(array $running_jobs, string $node): array {
                                  'jobs' => [], 'jobs_pl' => []];
         }
         $job_entry = ['cpus' => $job['cpus_per_node'], 'mem' => $job['mem_per_node'], 'gpus' => $job['gpus_per_node']];
-        $is_plow = ($job['partition'] ?? '') === 'p_low';
-        if ($is_plow) {
+        if ( ($job['partition'] ?? '') === 'p_low' ) {
             $breakdown[$user]['cpus_pl'] += $job['cpus_per_node'];
             $breakdown[$user]['mem_pl']  += $job['mem_per_node'];
             $breakdown[$user]['gpus_pl'] += $job['gpus_per_node'];
@@ -63,7 +167,243 @@ function _build_node_user_breakdown(array $running_jobs, string $node): array {
 }
 
 /**
+ * Renders the cluster-wide resource summary card.
+ * Shows stacked progress bars for CPUs, Memory, and GPUs across all nodes.
+ * Striped yellow segments mark resources on nodes where all CPUs or memory are already taken.
+ *
+ * @param array $totals          Keys: cpus, cpus_alloc, mem_total, mem_alloc,
+ *                                     gpus_total, gpus_used, cpus_unusable, mem_unusable, gpus_unusable
+ * @param array $user_breakdown  [username => ['cpus','mem','gpus','cpus_pl','mem_pl','gpus_pl']]
+ * @param bool  $show_users      Whether per-user breakdown is currently active (GET param set)
+ * @param string $nonce          CSP nonce for the inline script
+ * @param bool  $can_show_users  Whether the current user is allowed to see the per-user breakdown
+ */
+function _render_cluster_summary(array $totals, array $user_breakdown, bool $show_users, string $nonce = '', bool $can_show_users = FALSE, bool $show_plow = FALSE): string {
+    $has_gpu  = $totals['gpus_total'] > 0;
+    $has_plow = $show_users && (
+        array_sum(array_column($user_breakdown, 'cpus_pl')) +
+        array_sum(array_column($user_breakdown, 'mem_pl'))  +
+        array_sum(array_column($user_breakdown, 'gpus_pl')) > 0
+    );
+
+    $html  = '<div class="card mb-3" id="cluster-summary-card">' . "\n";
+    $html .= '<div class="card-header d-flex justify-content-between align-items-center">'
+           . '<strong>Cluster-wide resource summary</strong>';
+    if ($can_show_users) {
+        $html .= '<div class="form-check form-switch mb-0">'
+               . '<input class="form-check-input" type="checkbox" id="clusterShowUsers"' . ($show_users ? ' checked' : '') . '>'
+               . '<label class="form-check-label" for="clusterShowUsers">Show users</label>'
+               . '</div>';
+    }
+    $html .= '</div>' . "\n";
+
+    $html .= '<div class="card-body py-2">' . "\n";
+    $html .= '<table class="table table-borderless mb-0">' . "\n";
+
+    $rows = [
+        ['label' => 'CPUs',   'used' => $totals['cpus_alloc'], 'total' => $totals['cpus'],
+         'unusable' => $totals['cpus_unusable'], 'plow' => $show_plow ? $totals['cpus_plow'] : 0,
+         'key' => 'cpus', 'key_pl' => 'cpus_pl', 'suffix' => ' CPUs'],
+        ['label' => 'Memory', 'used' => $totals['mem_alloc'],  'total' => $totals['mem_total'],
+         'unusable' => $totals['mem_unusable'],  'plow' => $show_plow ? $totals['mem_plow']  : 0,
+         'key' => 'mem',  'key_pl' => 'mem_pl',  'suffix' => ' MiB'],
+        ['label' => 'GPUs',   'used' => $totals['gpus_used'],  'total' => $totals['gpus_total'],
+         'unusable' => $totals['gpus_unusable'], 'plow' => $show_plow ? $totals['gpus_plow'] : 0,
+         'key' => 'gpus', 'key_pl' => 'gpus_pl', 'suffix' => ' GPUs'],
+    ];
+    foreach ($rows as $row) {
+        if ((int)$row['total'] <= 0)
+            continue;
+
+        $html .= _render_cluster_bar_row_html($row, $user_breakdown, $show_users);
+    }
+
+    if ($show_users && !empty($user_breakdown))
+        $html .= _render_cluster_legend_row($user_breakdown, $totals['mem_total'] > 0, $has_gpu, $has_plow);
+
+    if (!$show_users && $show_plow && ($totals['cpus_plow'] > 0 || $totals['mem_plow'] > 0 || $totals['gpus_plow'] > 0)) {
+        $html .= '<tr><td></td><td><small class="text-muted">'
+               . '<span style="display:inline-block;width:14px;height:14px;vertical-align:middle;'
+               . 'background:repeating-linear-gradient(45deg,#0d6efd,#0d6efd 4px,#9ec5fe 4px,#9ec5fe 8px);'
+               . 'border:1px solid #ccc"></span>'
+               . ' Striped: <span class="monospaced">p_low</span> partition jobs'
+               . '</small></td></tr>' . "\n";
+    }
+    if ($totals['cpus_unusable'] > 0 || $totals['mem_unusable'] > 0 || $totals['gpus_unusable'] > 0) {
+        $html .= '<tr><td></td><td><small class="text-muted">'
+               . '<span style="display:inline-block;width:14px;height:14px;vertical-align:middle;'
+               . 'background:repeating-linear-gradient(45deg,#ffc107,#ffc107 4px,#fff3cd 4px,#fff3cd 8px);'
+               . 'border:1px solid #ccc"></span>'
+               . ' Unusable: free resources on nodes where all CPUs or memory are already allocated'
+               . '</small></td></tr>' . "\n";
+    }
+
+    $html .= '</table>' . "\n";
+    $html .= '</div>' . "\n";
+    $html .= '</div>' . "\n";
+
+    if ($can_show_users) {
+        $nonce_attr = $nonce !== '' ? ' nonce="' . htmlspecialchars($nonce, ENT_QUOTES, 'UTF-8') . '"' : '';
+        $html .= '<script' . $nonce_attr . '>'
+               . 'document.getElementById("clusterShowUsers").addEventListener("change",function(){'
+               . 'window.location.href="?action=usage&show_users="+(this.checked?"1":"0");'
+               . '});'
+               . '</script>' . "\n";
+    }
+
+    return $html;
+}
+
+/**
+ * Renders one &lt;tr&gt; for the cluster summary table: label + stacked progress bar + text summary.
+ */
+function _render_cluster_bar_row_html(array $res_def, array $user_breakdown, bool $show_users): string {
+    $label    = $res_def['label'];
+    $used     = (int)$res_def['used'];
+    $total    = (int)$res_def['total'];
+    $unusable = (int)$res_def['unusable'];
+    $key      = $res_def['key'];
+    $key_pl   = $res_def['key_pl'];
+    $suffix   = $res_def['suffix'];
+
+    $pct_used     = min(100.0, round($used / $total * 100, 1));
+    $unusable_cap = max(0, min($total - $used, $unusable));
+    $pct_unusable = round($unusable_cap / $total * 100, 1);
+
+    $html  = '<tr><td style="white-space:nowrap;padding-right:12px">'
+           . htmlspecialchars($label, ENT_QUOTES, 'UTF-8') . ':</td>';
+    $html .= '<td style="width:99%">';
+    $html .= '<div class="progress" style="height:22px">';
+
+    if ($show_users && !empty($user_breakdown)) {
+        foreach ($user_breakdown as $user => $res) {
+            foreach (['' => $key, '_pl' => $key_pl] as $type_sfx => $k) {
+                $val = (int)($res[$k] ?? 0);
+                if ($val <= 0)
+                    continue;
+
+                $pct    = min(100.0, round($val / $total * 100, 1));
+                $user_e = htmlspecialchars($user, ENT_QUOTES, 'UTF-8');
+                $is_pl  = ($type_sfx === '_pl');
+                $tip    = $user_e . ($is_pl ? ' (p_low)' : '') . ': '
+                        . number_format($val, 0, '.', ',') . $suffix . ' (' . $pct . '%)';
+                if ($is_pl) {
+                    $seg_cls = 'progress-bar progress-bar-striped bg-secondary';
+                    $seg_sty = 'width:' . $pct . '%;border-right:2px solid rgba(255,255,255,0.55)';
+                    $seg_txt = $pct >= 10 ? $user_e : '';
+                } else {
+                    $color   = _user_color($user);
+                    $seg_cls = 'progress-bar';
+                    $seg_sty = 'width:' . $pct . '%;background-color:' . $color['hex']
+                             . ';color:' . $color['text'] . ';border-right:2px solid rgba(255,255,255,0.55)';
+                    $seg_txt = $pct >= 8 ? $user_e : '';
+                }
+                $html .= '<div class="' . $seg_cls . '" role="progressbar" style="' . $seg_sty . '"'
+                       . ' data-bs-toggle="tooltip" data-bs-trigger="hover focus"'
+                       . ' title="' . htmlspecialchars($tip, ENT_QUOTES, 'UTF-8') . '">'
+                       . $seg_txt . '</div>';
+            }
+        }
+    } else {
+        $plow   = max(0, min((int)($res_def['plow'] ?? 0), $used));
+        $normal = $used - $plow;
+
+        if ($normal > 0) {
+            $pct_normal = round($normal / $total * 100, 1);
+            $tip_n = 'In use: ' . number_format($normal, 0, '.', ',') . $suffix . ' (' . $pct_normal . '%)';
+            $html .= '<div class="progress-bar bg-primary" role="progressbar"'
+                   . ' style="width:' . $pct_normal . '%"'
+                   . ' data-bs-toggle="tooltip" data-bs-trigger="hover focus"'
+                   . ' title="' . htmlspecialchars($tip_n, ENT_QUOTES, 'UTF-8') . '">'
+                   . $pct_normal . '%</div>';
+        }
+        if ($plow > 0) {
+            $pct_plow = round($plow / $total * 100, 1);
+            $tip_p = 'p_low jobs: ' . number_format($plow, 0, '.', ',') . $suffix . ' (' . $pct_plow . '%)';
+            $html .= '<div class="progress-bar" role="progressbar"'
+                   . ' style="width:' . $pct_plow . '%;background:repeating-linear-gradient(45deg,#0d6efd,#0d6efd 6px,#9ec5fe 6px,#9ec5fe 12px)"'
+                   . ' data-bs-toggle="tooltip" data-bs-trigger="hover focus"'
+                   . ' title="' . htmlspecialchars($tip_p, ENT_QUOTES, 'UTF-8') . '">'
+                   . $pct_plow . '%</div>';
+        }
+    }
+
+    if ($pct_unusable > 0) {
+        $tip_u = 'Unusable (CPU-full nodes): '
+               . number_format($unusable_cap, 0, '.', ',') . $suffix . ' (' . $pct_unusable . '%)';
+        $html .= '<div class="progress-bar progress-bar-striped bg-warning text-dark" role="progressbar"'
+               . ' style="width:' . $pct_unusable . '%"'
+               . ' data-bs-toggle="tooltip" data-bs-trigger="hover focus"'
+               . ' title="' . htmlspecialchars($tip_u, ENT_QUOTES, 'UTF-8') . '"></div>';
+    }
+
+    $html .= '</div>'; // .progress
+    $html .= '<small class="text-muted">'
+           . number_format($used, 0, '.', ',') . ' / ' . number_format($total, 0, '.', ',')
+           . $suffix . ' in use (' . $pct_used . '%)';
+    if ($pct_unusable > 0) {
+        $html .= ' &mdash; <span class="text-warning fw-bold">'
+               . number_format($unusable_cap, 0, '.', ',') . $suffix . ' unusable</span>';
+    }
+    $html .= '</small>';
+    $html .= '</td></tr>' . "\n";
+
+    return $html;
+}
+
+/**
+ * Builds the badge HTML for all users in a breakdown (regular or p_low jobs).
+ * Returns a concatenated string of <span class="badge"> elements.
+ */
+function _build_user_badges(array $user_breakdown, bool $is_plow, bool $has_mem, bool $has_gpu): string {
+    $sfx  = $is_plow ? '_pl' : '';
+    $html = '';
+    foreach ($user_breakdown as $user => $res) {
+        if (($res['cpus'.$sfx] ?? 0) <= 0 && ($res['mem'.$sfx] ?? 0) <= 0 && ($res['gpus'.$sfx] ?? 0) <= 0)
+            continue;
+        $user_e = htmlspecialchars($user, ENT_QUOTES, 'UTF-8');
+        $det    = [];
+        if (($res['cpus'.$sfx] ?? 0) > 0)
+            $det[] = number_format($res['cpus'.$sfx], 0, '.', ',') . ' CPUs';
+        if (($res['mem'.$sfx]  ?? 0) > 0 && $has_mem)
+            $det[] = number_format($res['mem'.$sfx],  0, '.', ',') . ' MiB';
+        if (($res['gpus'.$sfx] ?? 0) > 0 && $has_gpu)
+            $det[] = number_format($res['gpus'.$sfx], 0, '.', ',') . ' GPUs';
+        $det_str = empty($det) ? '' : ': ' . htmlspecialchars(implode(', ', $det), ENT_QUOTES, 'UTF-8');
+        if ($is_plow) {
+            $html .= '<span class="badge bg-secondary progress-bar-striped text-white" style="background-size:1rem 1rem">'
+                   . '<a href="?action=users&user_name=' . $user_e . '" class="text-white" style="text-decoration:none">'
+                   . $user_e . '</a>' . $det_str . '</span>';
+        } else {
+            $color = _user_color($user);
+            $html .= '<span class="badge" style="background-color:' . $color['hex'] . ';color:' . $color['text'] . '">'
+                   . '<a href="?action=users&user_name=' . $user_e . '" style="color:' . $color['text'] . ';text-decoration:none">'
+                   . $user_e . '</a>' . $det_str . '</span>';
+        }
+    }
+    return $html;
+}
+
+/**
+ * Renders badge legend rows (regular + p_low) for the cluster summary.
+ */
+function _render_cluster_legend_row(array $user_breakdown, bool $has_mem, bool $has_gpu, bool $has_plow): string {
+    $html = '<tr><td style="white-space:nowrap">Users:</td>'
+          . '<td><div style="display:flex;flex-wrap:wrap;gap:4px">'
+          . _build_user_badges($user_breakdown, FALSE, $has_mem, $has_gpu)
+          . '</div></td></tr>' . "\n";
+    if ($has_plow) {
+        $html .= '<tr><td style="white-space:nowrap"><span class="monospaced">p_low</span>:</td>'
+               . '<td><div style="display:flex;flex-wrap:wrap;gap:4px">'
+               . _build_user_badges($user_breakdown, TRUE, $has_mem, $has_gpu)
+               . '</div></td></tr>' . "\n";
+    }
+    return $html;
+}
+
+/**
  * Converts HSL (h: 0–359, s/l: 0–1) to [R, G, B] each 0–255.
+ * Used to give users an individual color (based on their hash(username)).
  */
 function _hsl_to_rgb(int $h, float $s, float $l): array {
     $c = (1 - abs(2 * $l - 1)) * $s;
@@ -143,9 +483,11 @@ function _render_user_breakdown(array $user_breakdown, int $cpu_total, int $mem_
             $user_e = htmlspecialchars($user, ENT_QUOTES, 'UTF-8');
             foreach ($res['jobs'] as $job) {
                 $val = $job[$res_def['key']] ?? 0;
+
                 if ($val <= 0)
                     continue;
-                $pct     = min(100.0, round($val / $total * 100, 1));
+
+                $pct   = min(100.0, round($val / $total * 100, 1));
                 $val_f = number_format($val, 0, '.', ',');
                 $tooltip = $user_e . ': ' . $val_f . $res_def['suffix'] . ' (' . $pct . '%)';
                 $html .= '<div class="progress-bar" role="progressbar"'
@@ -161,9 +503,11 @@ function _render_user_breakdown(array $user_breakdown, int $cpu_total, int $mem_
             $user_e = htmlspecialchars($user, ENT_QUOTES, 'UTF-8');
             foreach ($res['jobs_pl'] as $job) {
                 $val = $job[$res_def['key']] ?? 0;
+
                 if ($val <= 0)
                     continue;
-                $pct     = min(100.0, round($val / $total * 100, 1));
+
+                $pct   = min(100.0, round($val / $total * 100, 1));
                 $val_f = number_format($val, 0, '.', ',');
                 $tooltip = $user_e . ' (p_low): ' . $val_f . $res_def['suffix'] . ' (' . $pct . '%)';
                 $html .= '<div class="progress-bar progress-bar-striped bg-secondary" role="progressbar"'
@@ -177,59 +521,38 @@ function _render_user_breakdown(array $user_breakdown, int $cpu_total, int $mem_
         $html .= '</div></td></tr>';
     }
 
-    // Regular-jobs legend row
-    $regular_badges = '';
-    foreach ($user_breakdown as $user => $res) {
-        if (($res['cpus'] ?? 0) <= 0 && ($res['mem'] ?? 0) <= 0 && ($res['gpus'] ?? 0) <= 0)
-            continue;
-        $color  = _user_color($user);
-        $user_e = htmlspecialchars($user, ENT_QUOTES, 'UTF-8');
-        $details = [];
-        if (($res['cpus'] ?? 0) > 0)
-            $details[] = number_format($res['cpus'], 0, '.', ',') . ' CPUs';
-        if (($res['mem']  ?? 0) > 0 && $has_mem)
-            $details[] =  number_format($res['mem'], 0, '.', ',') . ' MiB';
-        if (($res['gpus'] ?? 0) > 0 && $has_gpu)
-            $details[] = number_format($res['gpus'], 0, '.', ',') . ' GPUs';
-        $regular_badges .= '<span class="badge" style="background-color:' . $color['hex'] . ';color:' . $color['text'] . '">'
-                         . '<a href="?action=users&user_name=' . $user_e . '" style="color:' . $color['text'] . ';text-decoration:none">' . $user_e . '</a>'
-                         . (empty($details) ? '' : ': ' . htmlspecialchars(implode(', ', $details), ENT_QUOTES, 'UTF-8'))
-                         . '</span>';
-    }
+    // Legend rows
     $html .= '<tr><td>Normal jobs:</td>'
-           . '<td><div style="display:flex;flex-wrap:wrap;gap:4px">' . $regular_badges . '</div></td></tr>';
-
-    // p_low-jobs legend row (only when p_low jobs exist)
+           . '<td><div style="display:flex;flex-wrap:wrap;gap:4px">'
+           . _build_user_badges($user_breakdown, FALSE, $has_mem, $has_gpu)
+           . '</div></td></tr>';
     if ($has_plow) {
-        $plow_badges = '';
-        foreach ($user_breakdown as $user => $res) {
-            if (($res['cpus_pl'] ?? 0) <= 0 && ($res['mem_pl'] ?? 0) <= 0 && ($res['gpus_pl'] ?? 0) <= 0)
-                continue;
-            $user_e  = htmlspecialchars($user, ENT_QUOTES, 'UTF-8');
-            $details = [];
-            if (($res['cpus_pl'] ?? 0) > 0)
-                $details[] = number_format($res['cpus_pl'], 0, '.', ',') . ' CPUs';
-            if (($res['mem_pl']  ?? 0) > 0 && $has_mem)
-                $details[] =  number_format($res['mem_pl'], 0, '.', ',') . ' MiB';
-            if (($res['gpus_pl'] ?? 0) > 0 && $has_gpu)
-                $details[] = number_format($res['gpus_pl'], 0, '.', ',') . ' GPUs';
-            $plow_badges .= '<span class="badge bg-secondary progress-bar-striped text-white" style="background-size:1rem 1rem">'
-                          . '<a href="?action=users&user_name=' . $user_e . '" class="text-white" style="text-decoration:none">' . $user_e . '</a>'
-                          . (empty($details) ? '' : ': ' . htmlspecialchars(implode(', ', $details), ENT_QUOTES, 'UTF-8'))
-                          . '</span>';
-        }
         $html .= '<tr><td><span class="monospaced">p_low</span> jobs:</td>'
-               . '<td><div style="display:flex;flex-wrap:wrap;gap:4px">' . $plow_badges . '</div></td></tr>';
+               . '<td><div style="display:flex;flex-wrap:wrap;gap:4px">'
+               . _build_user_badges($user_breakdown, TRUE, $has_mem, $has_gpu)
+               . '</div></td></tr>';
     }
 
     return $html;
 }
 
-function get_usage(array $data, array $user_breakdown = []) : string {
+function get_usage(array $data, array $user_breakdown = [], string $show_users_toggle = '') : string {
     $contents = '';
 
     $templateBuilder = new TemplateLoader("nodeinfo.html");
-    $templateBuilder->setParam("NODENAME", htmlspecialchars($data['node_name'], ENT_QUOTES, 'UTF-8'));
+    $nodename_e = htmlspecialchars($data['node_name'], ENT_QUOTES, 'UTF-8');
+    $templateBuilder->setParam("NODENAME", $nodename_e);
+
+    if (\auth\current_user_is_admin()) {
+        $node_state_actions =
+            '<li><a class="dropdown-item" href="?action=node-set-state&nodename=' . $nodename_e . '&state=resume">Resume node</a></li>' .
+            '<li><a class="dropdown-item" href="?action=node-set-state&nodename=' . $nodename_e . '&state=drain">Drain node</a></li>';
+    } else {
+        $node_state_actions =
+            '<li><a class="dropdown-item disabled" aria-disabled="true" tabindex="-1">Resume node</a></li>' .
+            '<li><a class="dropdown-item disabled" aria-disabled="true" tabindex="-1">Drain node</a></li>';
+    }
+    $templateBuilder->setParam("NODE_STATE_ACTIONS", $node_state_actions);
 
     $templateBuilder->setParam("CPU_PERCENTAGE", number_format($data["cpus"] > 0 ? $data["alloc_cpus"]/$data["cpus"]*100 : 0, 2));
     $templateBuilder->setParam("CPU_USED", $data["alloc_cpus"]);
@@ -320,6 +643,7 @@ function get_usage(array $data, array $user_breakdown = []) : string {
     $templateBuilder->setParam("PARTITIONS", count($escaped_partitions) > 0 ? '<li><span class="monospaced">' . implode('</span></li><li><span class="monospaced">', $escaped_partitions) . '</span></li>' : '');
     $templateBuilder->setParam("RESERVATION", htmlspecialchars($data["reservation"] ?? '', ENT_QUOTES, 'UTF-8'));
     $templateBuilder->setParam("SLURM_VERSION", $data["slurm_version"] ?? '');
+    $templateBuilder->setParam("SHOW_USERS_TOGGLE", $show_users_toggle);
 
     $contents .= $templateBuilder->build();
 

--- a/view/usage.tpl.php
+++ b/view/usage.tpl.php
@@ -3,7 +3,204 @@ namespace view\actions;
 
 use TemplateLoader;
 
-function get_usage(array $data) : string {
+/**
+ * Renders the full cluster-usage section including all nodes.
+ * Fetches running-job summaries once and distributes them per node.
+ * @param \client\Client $dao Client to query the data.
+ * @return string The usage data as HTML string.
+ */
+function get_all_nodes_usage(\client\Client $dao): string {
+    $contents = '';
+    $running_jobs = config('feature_resources_per_user') ? $dao->get_running_jobs_summary() : [];
+    foreach ($dao->getNodeList() as $node) {
+        $contents .= get_usage(
+            $dao->get_node_info($node),
+            $running_jobs ? _build_node_user_breakdown($running_jobs, $node) : []
+        );
+    }
+    return $contents;
+}
+
+/**
+ * Groups running-job summaries by user for a single node. p_low resources tracked separately via _pl suffix.
+ * @param array $running_jobs Array of running jobs, as returns by \\Client\\get_running_jobs_summary
+ * @param string $node Node name.
+ */
+function _build_node_user_breakdown(array $running_jobs, string $node): array {
+    $breakdown = [];
+    foreach ($running_jobs as $job) {
+        if (!\utils\node_is_in_nodelist($node, $job['nodes_str'])) continue;
+        $user = $job['user_name'];
+        if (!isset($breakdown[$user])) {
+            $breakdown[$user] = ['cpus' => 0, 'mem' => 0, 'gpus' => 0,
+                                 'cpus_pl' => 0, 'mem_pl' => 0, 'gpus_pl' => 0,
+                                 'jobs' => [], 'jobs_pl' => []];
+        }
+        $job_entry = ['cpus' => $job['cpus_per_node'], 'mem' => $job['mem_per_node'], 'gpus' => $job['gpus_per_node']];
+        $is_plow = ($job['partition'] ?? '') === 'p_low';
+        if ($is_plow) {
+            $breakdown[$user]['cpus_pl'] += $job['cpus_per_node'];
+            $breakdown[$user]['mem_pl']  += $job['mem_per_node'];
+            $breakdown[$user]['gpus_pl'] += $job['gpus_per_node'];
+            $breakdown[$user]['jobs_pl'][] = $job_entry;
+        } else {
+            $breakdown[$user]['cpus'] += $job['cpus_per_node'];
+            $breakdown[$user]['mem']  += $job['mem_per_node'];
+            $breakdown[$user]['gpus'] += $job['gpus_per_node'];
+            $breakdown[$user]['jobs'][] = $job_entry;
+        }
+    }
+    ksort($breakdown);
+    return $breakdown;
+}
+
+/**
+ * Renders the per-user resource breakdown as table rows with stacked progress bars.
+ * p_low partition jobs are shown as gray striped segments and listed separately.
+ * @return string an empty string when no jobs are running on the node, the usage data as HTML otherwise
+ */
+function _render_user_breakdown(array $user_breakdown, int $cpu_total, int $mem_total, int $gpu_total): string {
+    if (empty($user_breakdown))
+        return '';
+
+    // Bootstrap background/text color pairs (index-stable)
+    $bg_colors   = ['primary', 'success', 'danger', 'warning', 'info', 'secondary', 'dark'];
+    $text_colors = ['text-white', 'text-white', 'text-white', 'text-dark', 'text-dark', 'text-white', 'text-white'];
+
+    $color_idx = function(string $user) use ($bg_colors): int {
+        return abs(crc32($user)) % count($bg_colors);
+    };
+
+    // Check totals across both regular and p_low resources
+    $has_mem  = $mem_total > 0 && (
+        array_sum(array_column($user_breakdown, 'mem')) +
+        array_sum(array_column($user_breakdown, 'mem_pl')) > 0
+    );
+    $has_gpu  = $gpu_total > 0 && (
+        array_sum(array_column($user_breakdown, 'gpus')) +
+        array_sum(array_column($user_breakdown, 'gpus_pl')) > 0
+    );
+    $has_plow = (
+        array_sum(array_column($user_breakdown, 'cpus_pl')) +
+        array_sum(array_column($user_breakdown, 'mem_pl')) +
+        array_sum(array_column($user_breakdown, 'gpus_pl')) > 0
+    );
+
+    $html = '<tr><td colspan="2"><strong>Current resource usage per user</strong></td></tr>';
+
+    // One stacked-bar row per resource type
+    $resources = [
+        ['key' => 'cpus', 'key_pl' => 'cpus_pl', 'total' => $cpu_total, 'show' => $cpu_total > 0, 'label' => 'CPUs by user:',   'suffix' => ' CPUs'],
+        ['key' => 'mem',  'key_pl' => 'mem_pl',  'total' => $mem_total, 'show' => $has_mem,       'label' => 'Memory by user:', 'suffix' => ' MiB'],
+        ['key' => 'gpus', 'key_pl' => 'gpus_pl', 'total' => $gpu_total, 'show' => $has_gpu,       'label' => 'GPUs by user:',   'suffix' => ' GPUs'],
+    ];
+
+    foreach ($resources as $res_def) {
+        if (!$res_def['show'])
+            continue;
+        $total = $res_def['total'];
+        $html .= '<tr><td style="font-size:0.85em;white-space:nowrap">' . $res_def['label'] . '</td><td>';
+        $html .= '<div class="progress" style="height:20px">';
+
+        // Regular (colored) segments — one per individual job, with a white divider between jobs
+        foreach ($user_breakdown as $user => $res) {
+            $idx = $color_idx($user);
+            $user_e = htmlspecialchars($user, ENT_QUOTES, 'UTF-8');
+            foreach ($res['jobs'] as $job) {
+                $val = $job[$res_def['key']] ?? 0;
+                if ($val <= 0) continue;
+                $pct = min(100.0, round($val / $total * 100, 1));
+                $tooltip = $user_e . ': ' . $val . $res_def['suffix'] . ' (' . $pct . '%)';
+                $html .= '<div class="progress-bar bg-' . $bg_colors[$idx] . ' ' . $text_colors[$idx] . '"'
+                       . ' role="progressbar"'
+                       . ' style="width:' . $pct . '%;border-right:2px solid rgba(255,255,255,0.55)"'
+                       . ' data-bs-toggle="tooltip" data-bs-trigger="hover focus"'
+                       . ' title="' . htmlspecialchars($tooltip, ENT_QUOTES, 'UTF-8') . '">'
+                       . ($pct >= 12 ? $user_e : '') . '</div>';
+            }
+        }
+
+        // p_low (gray striped) segments — one per individual job
+        foreach ($user_breakdown as $user => $res) {
+            $user_e = htmlspecialchars($user, ENT_QUOTES, 'UTF-8');
+            foreach ($res['jobs_pl'] as $job) {
+                $val = $job[$res_def['key']] ?? 0;
+                if ($val <= 0) continue;
+                $pct = min(100.0, round($val / $total * 100, 1));
+                $tooltip = $user_e . ' (p_low): ' . $val . $res_def['suffix'] . ' (' . $pct . '%)';
+                $html .= '<div class="progress-bar progress-bar-striped bg-secondary"'
+                       . ' role="progressbar"'
+                       . ' style="width:' . $pct . '%;border-right:2px solid rgba(255,255,255,0.55)"'
+                       . ' data-bs-toggle="tooltip" data-bs-trigger="hover focus"'
+                       . ' title="' . htmlspecialchars($tooltip, ENT_QUOTES, 'UTF-8') . '">'
+                       . ($pct >= 12 ? $user_e : '') . '</div>';
+            }
+        }
+
+        $html .= '</div></td></tr>';
+    }
+
+    // Legend row
+    $html .= '<tr><td style="font-size:0.85em;white-space:nowrap">Normal jobs:</td><td>';
+
+    // Regular badges
+    $regular_badges = '';
+    foreach ($user_breakdown as $user => $res) {
+        $has_regular = ($res['cpus'] ?? 0) > 0 || ($res['mem'] ?? 0) > 0 || ($res['gpus'] ?? 0) > 0;
+        if ( !$has_regular )
+            continue;
+        $user_e = htmlspecialchars($user, ENT_QUOTES, 'UTF-8');
+        $idx = $color_idx($user);
+        $details = [];
+        if (($res['cpus'] ?? 0) > 0)
+            $details[] = $res['cpus'] . ' CPUs';
+        if (($res['mem']  ?? 0) > 0 && $has_mem)
+            $details[] = $res['mem']  . ' MiB';
+        if (($res['gpus'] ?? 0) > 0 && $has_gpu)
+            $details[] = $res['gpus'] . ' GPUs';
+        $detail_str = implode(', ', $details);
+        $regular_badges .= '<span class="badge bg-' . $bg_colors[$idx] . ' ' . $text_colors[$idx] . '">'
+                         . '<a href="?action=users&user_name=' . $user_e . '" class="' . $text_colors[$idx] . '" style="text-decoration:none">' . $user_e . '</a>'
+                         . (empty($detail_str) ? '' : ': ' . htmlspecialchars($detail_str, ENT_QUOTES, 'UTF-8'))
+                         . '</span>';
+    }
+
+    // p_low badges (only if any p_low jobs exist)
+    $plow_badges = '';
+    if ($has_plow) {
+        foreach ($user_breakdown as $user => $res) {
+            $has_pl = ($res['cpus_pl'] ?? 0) > 0 || ($res['mem_pl'] ?? 0) > 0 || ($res['gpus_pl'] ?? 0) > 0;
+            if (!$has_pl)
+                continue;
+            $user_e = htmlspecialchars($user, ENT_QUOTES, 'UTF-8');
+            $details = [];
+            if (($res['cpus_pl'] ?? 0) > 0)
+                $details[] = $res['cpus_pl'] . ' CPUs';
+            if (($res['mem_pl']  ?? 0) > 0 && $has_mem)
+                $details[] = $res['mem_pl']  . ' MiB';
+            if (($res['gpus_pl'] ?? 0) > 0 && $has_gpu)
+                $details[] = $res['gpus_pl'] . ' GPUs';
+            $detail_str = implode(', ', $details);
+            $plow_badges .= '<span class="badge bg-secondary progress-bar-striped text-white"'
+                          . ' style="background-size:1rem 1rem">'
+                          . '<a href="?action=users&user_name=' . $user_e . '" class="text-white" style="text-decoration:none">' . $user_e . '</a>'
+                          . (empty($detail_str) ? '' : ': ' . htmlspecialchars($detail_str, ENT_QUOTES, 'UTF-8'))
+                          . '</span>';
+        }
+    }
+
+    $html .= '<div style="display:flex;flex-wrap:wrap;gap:4px">' . $regular_badges . '</div>';
+    $html .= '</td></tr>';
+
+    if (!empty($plow_badges)) {
+        $html .= '<tr><td style="font-size:0.85em;white-space:nowrap">p_low jobs:</td>'
+               . '<td><div style="display:flex;flex-wrap:wrap;gap:4px">' . $plow_badges . '</div></td></tr>';
+    }
+
+    return $html;
+}
+
+function get_usage(array $data, array $user_breakdown = []) : string {
     $contents = '';
 
     $templateBuilder = new TemplateLoader("nodeinfo.html");
@@ -41,6 +238,13 @@ function get_usage(array $data) : string {
     $templateBuilder->setParam("GPU_PERCENTAGE", number_format($gpus_percentage, 2));
     $templateBuilder->setParam("GPU_USED", $gpus_used);
     $templateBuilder->setParam("GPU_TOTAL", $gpus);
+
+    $templateBuilder->setParam("USER_RESOURCE_BREAKDOWN", _render_user_breakdown(
+        $user_breakdown,
+        (int)$data['cpus'],
+        (int)$data['mem_total'],
+        (int)$gpus
+    ));
 
     $templateBuilder->setParam("STATE", implode(", ", $data["state"]));
     $state_color = "#f9c98f"; # orange

--- a/view/usage.tpl.php
+++ b/view/usage.tpl.php
@@ -134,7 +134,7 @@ function _render_user_breakdown(array $user_breakdown, int $cpu_total, int $mem_
         if (!$res_def['show'])
             continue;
         $total = $res_def['total'];
-        $html .= '<tr><td style="font-size:0.85em;white-space:nowrap">' . $res_def['label'] . '</td><td>';
+        $html .= '<tr><td>' . $res_def['label'] . '</td><td>';
         $html .= '<div class="progress" style="height:20px">';
 
         // Regular (colored) segments — one per individual job, with a white divider between jobs
@@ -194,7 +194,7 @@ function _render_user_breakdown(array $user_breakdown, int $cpu_total, int $mem_
                          . (empty($details) ? '' : ': ' . htmlspecialchars(implode(', ', $details), ENT_QUOTES, 'UTF-8'))
                          . '</span>';
     }
-    $html .= '<tr><td style="font-size:0.85em;white-space:nowrap">Normal jobs:</td>'
+    $html .= '<tr><td>Normal jobs:</td>'
            . '<td><div style="display:flex;flex-wrap:wrap;gap:4px">' . $regular_badges . '</div></td></tr>';
 
     // p_low-jobs legend row (only when p_low jobs exist)
@@ -216,7 +216,7 @@ function _render_user_breakdown(array $user_breakdown, int $cpu_total, int $mem_
                           . (empty($details) ? '' : ': ' . htmlspecialchars(implode(', ', $details), ENT_QUOTES, 'UTF-8'))
                           . '</span>';
         }
-        $html .= '<tr><td style="font-size:0.85em;white-space:nowrap">p_low jobs:</td>'
+        $html .= '<tr><td><span class="monospaced">p_low</span> jobs:</td>'
                . '<td><div style="display:flex;flex-wrap:wrap;gap:4px">' . $plow_badges . '</div></td></tr>';
     }
 


### PR DESCRIPTION
Display cluster usage information (CPUs, memory, gpus per node) per node and user. (This feature is disabled per default and can be enabled for all users or for privileged users only.)

This merge request adds two new opt-in features controlled via environment variables:
- `FEATURE_RESOURCES_PER_USER` (`disabled` default, `all` for all users and `privileged` for privileged users only): Shows a per-user CPU/RAM/GPU breakdown with stacked progress bars on the cluster usage page. Each user gets a hash-derived color. `p_low` partition jobs are shown as separate gray striped segments.
  Note that when the feature is enabled, an extra API call to `/slurm/jobs` is required.
- `FEATURE_P_LOW_IN_CLUSTER_OVERVIEW` (`enabled` or `disabled`, disabled by default): Shows `p_low` partition jobs as a separate striped blue segment in the cluster-wide overview bars. This feature is disabled per default because it also requires an extra API call to `/slurm/jobs`.

Other changes:
- Node state actions (Resume/Drain) are now disabled (greyed out) for non-admin users instead of always being clickable
- Memory values on node cards now formatted with thousands separators