### PR TITLE
Feature multipleselect filter

### DIFF
--- a/client/AbstractClient.inc.php
+++ b/client/AbstractClient.inc.php
@@ -84,13 +84,26 @@ abstract class AbstractClient implements Client {
                 $query_string .= '&end_time=uts' . (int)$filter['end_time'];
             }
             if(isset($filter['users'])){
-                $query_string .= '&users=' . urlencode($filter['users']);
+                // Repeated parameters (users=a&users=b): slurmrestd uses array
+                // serialization here despite documenting a "CSV list".
+                foreach($filter['users'] as $u){
+                    $query_string .= '&users=' . urlencode($u);
+                }
             }
             if(isset($filter['account'])){
-                $query_string .= '&account=' . urlencode($filter['account']);
+                foreach($filter['account'] as $a){
+                    $query_string .= '&account=' . urlencode($a);
+                }
+            }
+            if(isset($filter['partition'])){
+                foreach($filter['partition'] as $p){
+                    $query_string .= '&partition=' . urlencode($p);
+                }
             }
             if(isset($filter['node'])){
-                $query_string .= '&node=' . urlencode($filter['node']);
+                foreach($filter['node'] as $n){
+                    $query_string .= '&node=' . urlencode($n);
+                }
             }
             if(isset($filter['job_name'])){
                 $query_string .= '&job_name=' . urlencode($filter['job_name']);
@@ -103,13 +116,9 @@ abstract class AbstractClient implements Client {
                  * Issue 12 specific code
                  * See https://github.com/nikolaussuess/slurm-dashboard/issues/12
                  */
-                if(
-                    $filter['state'] != 'COMPLETED' &&
-                    $filter['state'] != 'FAILED' &&
-                    $filter['state'] != 'TIMEOUT' &&
-                    $filter['state'] != 'OUT_OF_MEMORY'
-                ){
-                    $query_string .= '&state=' . urlencode($filter['state']);
+                $broken = ['COMPLETED', 'FAILED', 'TIMEOUT', 'OUT_OF_MEMORY'];
+                if(count($filter['state']) === 1 && !in_array($filter['state'][0], $broken, TRUE)){
+                    $query_string .= '&state=' . urlencode($filter['state'][0]);
                 }
                 // ORIGINAL CODE:
                 // $query_string .= '&state=' . $filter['state'];
@@ -124,25 +133,14 @@ abstract class AbstractClient implements Client {
         /*
          * Issue 12 specific code
          * See https://github.com/nikolaussuess/slurm-dashboard/issues/12
+         * RUNNING works on server side; COMPLETED/FAILED/TIMEOUT/OUT_OF_MEMORY do not.
+         * Multiple selected states are also always post-filtered here.
          */
-        // RUNNING works on server side
-        // COMPLETED does not
-        if(isset($filter['state']) && $filter['state'] == 'COMPLETED'){
-            $jobs_array = $this->_issue12_bugfix_post_request_filtering($json['jobs'], 'COMPLETED');
-            $json['jobs'] = $jobs_array;
-        }
-        // FAILED does not
-        elseif(isset($filter['state']) && $filter['state'] == 'FAILED'){
-            $jobs_array = $this->_issue12_bugfix_post_request_filtering($json['jobs'], 'FAILED');
-            $json['jobs'] = $jobs_array;
-        }
-        elseif(isset($filter['state']) && $filter['state'] == 'TIMEOUT'){
-            $jobs_array = $this->_issue12_bugfix_post_request_filtering($json['jobs'], 'TIMEOUT');
-            $json['jobs'] = $jobs_array;
-        }
-        elseif(isset($filter['state']) && $filter['state'] == 'OUT_OF_MEMORY'){
-            $jobs_array = $this->_issue12_bugfix_post_request_filtering($json['jobs'], 'OUT_OF_MEMORY');
-            $json['jobs'] = $jobs_array;
+        if(isset($filter['state'])){
+            $broken = ['COMPLETED', 'FAILED', 'TIMEOUT', 'OUT_OF_MEMORY'];
+            if(count($filter['state']) > 1 || in_array($filter['state'][0], $broken, TRUE)){
+                $json['jobs'] = $this->_issue12_bugfix_post_request_filtering($json['jobs'], $filter['state']);
+            }
         }
         // END Issue 12
 
@@ -158,7 +156,7 @@ abstract class AbstractClient implements Client {
                 'user_name'  => $json_job['user'],
                 'account'    => $json_job['account'],
                 'partition'  => $json_job['partition'],
-                'time_limit' => $this->_get_timelimit_if_defined($json_job['time'], 'limit', 'inf'),
+                'time_limit' => $this->_get_timelimit_if_defined($json_job['time'], 'limit', 'infinite'),
                 'time_start' => $this->_get_date_from_unix($json_job['time'], 'start'),
                 'time_elapsed' => $this->_get_elapsed_time($json_job['time']),
                 'nodes'      => $json_job['nodes']
@@ -173,6 +171,12 @@ abstract class AbstractClient implements Client {
         # curl --unix-socket /run/slurmrestd/slurmrestd.socket http://slurm/slurmdb/v0.0.40/accounts
         $json = RequestFactory::newRequest()->request_json("accounts", 'slurmdb', static::api_version, 3600);
         return array_column($json['accounts'], 'name');
+    }
+
+    function get_partition_list(): array {
+        # curl --unix-socket /run/slurmrestd/slurmrestd.socket http://slurm/slurm/v0.0.43/partitions
+        $json = RequestFactory::newRequest()->request_json("partitions", 'slurm', static::api_version, 3600);
+        return array_column($json['partitions'], 'name');
     }
 
     function get_users_list(): array {
@@ -515,15 +519,17 @@ abstract class AbstractClient implements Client {
      * Filtering for completed jobs does not work in slurmdb. Thus, we do not filter for them at the
      * request, but we filter the response.
      * See https://github.com/nikolaussuess/slurm-dashboard/issues/12
+     * @param array $jobs Raw job array from slurmdb response.
+     * @param array $states List of state strings; a job matches if it has any of them.
+     * @return array Filtered job array (re-indexed).
      */
-    protected function _issue12_bugfix_post_request_filtering(array $array, string $value): array {
-        return array_filter($array, function ($v, $k) use($value) {
-            foreach($v['state']['current'] as $state){
-                if( $state == $value )
-                    return TRUE;
+    protected function _issue12_bugfix_post_request_filtering(array $jobs, array $states): array {
+        return array_values(array_filter($jobs, function($job) use ($states) {
+            foreach($job['state']['current'] as $s){
+                if(in_array($s, $states, TRUE)) return TRUE;
             }
             return FALSE;
-        }, ARRAY_FILTER_USE_BOTH);
+        }));
     }
 
     function get_running_jobs_summary(): array {

--- a/client/Client.inc.php
+++ b/client/Client.inc.php
@@ -69,6 +69,12 @@ interface Client{
     function get_account_list(): array;
 
     /**
+     * Query the partition list as a list of strings.
+     * @return array List of strings with the partition names.
+     */
+    function get_partition_list(): array;
+
+    /**
      * Returns the list of Users as an array of strings with the usernames.
      * @return array List of Users as an array of strings with the usernames.
      */

--- a/public/index.php
+++ b/public/index.php
@@ -128,7 +128,7 @@ if( isset($_SESSION['USER']) ){
             $job_id_view = (int)$_GET['job_id'];
 
             # SLURM QUEUE information
-            $contents .= "<h2>Job " . $job_id_view . "</h2>";
+            // Title will also set <h1>
             $title = 'Job ' . $job_id_view;
             $query = $dao->get_job($job_id_view);
             if( $query == NULL ){

--- a/public/index.php
+++ b/public/index.php
@@ -191,11 +191,12 @@ if( isset($_SESSION['USER']) ){
             $accounts = $dao->get_account_list();
             $users = $dao->get_users_list();
             $nodes = $dao->getNodeList();
+            $partitions = $dao->get_partition_list();
 
-            $contents .= \view\actions\get_slurmdb_filter_form($filter, $accounts, $users, $nodes);
+            $contents .= \view\actions\get_slurmdb_filter_form($filter, $accounts, $users, $nodes, $partitions);
 
             $jobs = $dao->get_jobs_from_slurmdb($filter);
-            $contents .= \view\actions\get_filtered_jobs_from_slurmdb($jobs);
+            $contents .= \view\actions\get_filtered_jobs_from_slurmdb($jobs, $filter);
 
             break;
 
@@ -538,6 +539,7 @@ if( isset($_SESSION['USER']) ){
     </script>
 
     <link rel="stylesheet" href="/style.css" crossorigin="anonymous">
+    <script src="/multiselect.js"></script>
     <meta name="viewport" content="width=device-width, initial-scale=1" />
 </head>
 <body>

--- a/public/multiselect.js
+++ b/public/multiselect.js
@@ -82,7 +82,8 @@
                 const li = document.createElement('li');
                 li.className = 'ms-option'
                     + (opt.selected  ? ' ms-selected'  : '')
-                    + (opt.disabled  ? ' ms-disabled'  : '');
+                    + (opt.disabled  ? ' ms-disabled'  : '')
+                    + (opt.className ? ' ' + opt.className : '');
                 li.textContent = opt.text;
                 li.dataset.value = opt.value;
                 li.setAttribute('role', 'option');

--- a/public/multiselect.js
+++ b/public/multiselect.js
@@ -1,0 +1,251 @@
+/**
+ * multiselect.js — Searchable multi-select widget
+ *
+ * Progressively enhances every <select multiple class="multiselect-search">
+ * element into a chip-style combobox with live search. Without JavaScript the
+ * native <select multiple> remains fully functional (no-JS fallback).
+ *
+ * The native select is kept in the DOM (hidden) and stays authoritative for
+ * form submission — the widget only mirrors its state visually.
+ */
+(function () {
+    'use strict';
+
+    /**
+     * Replaces one <select multiple> with the custom widget.
+     * @param {HTMLSelectElement} select
+     */
+    function buildWidget(select) {
+        // Wrap the native select so we can position the dropdown relative to it.
+        const wrapper = document.createElement('div');
+        wrapper.className = 'ms-widget';
+        select.parentNode.insertBefore(wrapper, select);
+        wrapper.appendChild(select);
+
+        // Hide the native select; keep it in the DOM so the browser submits it.
+        select.style.display = 'none';
+        select.setAttribute('aria-hidden', 'true');
+
+        // --- Control bar (chips + search input) ---
+        const control = document.createElement('div');
+        control.className = 'ms-control form-control';
+
+        const chipsContainer = document.createElement('div');
+        chipsContainer.className = 'ms-chips';
+
+        const input = document.createElement('input');
+        input.type = 'text';
+        input.className = 'ms-search';
+        input.placeholder = 'Search…';
+        input.setAttribute('autocomplete', 'off');
+        // Derive accessible label from the associated <label> element.
+        const labelEl = select.id
+            ? document.querySelector('label[for="' + select.id + '"]')
+            : null;
+        input.setAttribute('aria-label', labelEl ? labelEl.textContent.trim() : 'Search');
+
+        control.appendChild(chipsContainer);
+        control.appendChild(input);
+        wrapper.insertBefore(control, select);
+
+        // --- Dropdown panel ---
+        const dropdown = document.createElement('div');
+        dropdown.className = 'ms-dropdown';
+
+        const optionsList = document.createElement('ul');
+        optionsList.className = 'ms-options';
+        optionsList.setAttribute('role', 'listbox');
+        optionsList.setAttribute('aria-multiselectable', 'true');
+
+        dropdown.appendChild(optionsList);
+        wrapper.appendChild(dropdown);
+
+        // --- Render helpers ---
+
+        /**
+         * Rebuilds the dropdown list, optionally filtered by a search string.
+         * Uses mousedown (not click) so the event fires before the input loses
+         * focus, which would otherwise close the dropdown before the click
+         * registers.
+         * @param {string} filterText
+         */
+        function renderOptions(filterText) {
+            optionsList.innerHTML = '';
+            const lower = filterText.toLowerCase();
+            let any = false;
+
+            function appendOption(opt) {
+                if (opt.value === '') return; // skip empty placeholder
+                if (lower && opt.text.toLowerCase().indexOf(lower) === -1) return;
+                any = true;
+
+                const li = document.createElement('li');
+                li.className = 'ms-option'
+                    + (opt.selected  ? ' ms-selected'  : '')
+                    + (opt.disabled  ? ' ms-disabled'  : '');
+                li.textContent = opt.text;
+                li.dataset.value = opt.value;
+                li.setAttribute('role', 'option');
+                li.setAttribute('aria-selected', opt.selected ? 'true' : 'false');
+
+                if (!opt.disabled) {
+                    li.addEventListener('mousedown', function (e) {
+                        e.preventDefault(); // prevent input from losing focus
+                        opt.selected = !opt.selected;
+                        renderChips();
+                        renderOptions(input.value);
+                    });
+                }
+
+                optionsList.appendChild(li);
+            }
+
+            Array.from(select.children).forEach(function (child) {
+                if (child.tagName === 'OPTGROUP') {
+                    // Render matching options first; only add the group header if
+                    // at least one option passes the filter.
+                    const groupEl = document.createElement('li');
+                    groupEl.className = 'ms-optgroup-label';
+                    groupEl.textContent = child.label;
+
+                    const before = optionsList.childElementCount;
+                    optionsList.appendChild(groupEl);
+                    Array.from(child.children).forEach(appendOption);
+
+                    // Remove the header again if no options were added under it.
+                    if (optionsList.childElementCount === before + 1) {
+                        optionsList.removeChild(groupEl);
+                    }
+                } else {
+                    appendOption(child);
+                }
+            });
+
+            if (!any) {
+                const li = document.createElement('li');
+                li.className = 'ms-option ms-no-results';
+                li.textContent = 'No results';
+                optionsList.appendChild(li);
+            }
+        }
+
+        /**
+         * Rebuilds the chip row from the currently selected native options.
+         */
+        function renderChips() {
+            chipsContainer.innerHTML = '';
+
+            Array.from(select.options).forEach(function (opt) {
+                if (!opt.selected || opt.value === '') return;
+
+                const chip = document.createElement('span');
+                chip.className = 'ms-chip';
+
+                const label = document.createElement('span');
+                label.textContent = opt.text;
+
+                const btn = document.createElement('button');
+                btn.type = 'button'; // prevent accidental form submission
+                btn.className = 'ms-chip-remove';
+                btn.textContent = '×';
+                btn.setAttribute('aria-label', 'Remove ' + opt.text);
+
+                btn.addEventListener('click', function (e) {
+                    e.stopPropagation(); // don't re-open the dropdown
+                    opt.selected = false;
+                    renderChips();
+                    renderOptions(input.value);
+                });
+
+                chip.appendChild(label);
+                chip.appendChild(btn);
+                chipsContainer.appendChild(chip);
+            });
+        }
+
+        function openDropdown() {
+            dropdown.classList.add('ms-open');
+            renderOptions(input.value);
+        }
+
+        function closeDropdown() {
+            dropdown.classList.remove('ms-open');
+            input.value = ''; // clear search when closing
+        }
+
+        // --- Event wiring ---
+
+        // Open dropdown when the user clicks the control bar.
+        control.addEventListener('click', function () {
+            if (!dropdown.classList.contains('ms-open')) {
+                openDropdown();
+                input.focus();
+            }
+        });
+
+        // Re-filter options as the user types.
+        input.addEventListener('input', function () {
+            renderOptions(input.value);
+        });
+
+        // Escape closes the dropdown and returns focus to the control.
+        input.addEventListener('keydown', function (e) {
+            if (e.key === 'Escape') {
+                closeDropdown();
+                input.blur();
+            }
+        });
+
+        // Close when the user clicks anywhere outside the widget.
+        document.addEventListener('mousedown', function (e) {
+            if (!wrapper.contains(e.target)) {
+                closeDropdown();
+            }
+        });
+
+        // Populate chips for any options that are already selected (page reload
+        // with preserved filter values).
+        renderChips();
+    }
+
+    /**
+     * Wires up the active-filter chip bar: adds × removal buttons to each
+     * .filter-chip element and submits the filter form when one is clicked.
+     */
+    function initFilterChips() {
+        var form = document.querySelector('form[action*="job_history"]');
+        if (!form) return;
+
+        document.querySelectorAll('.filter-chip').forEach(function (chip) {
+            var btn = document.createElement('button');
+            btn.type = 'button';
+            btn.className = 'filter-chip-remove';
+            btn.textContent = '×';
+            btn.setAttribute('aria-label', 'Remove filter');
+
+            btn.addEventListener('click', function () {
+                var field = chip.dataset.field;
+                var value = chip.dataset.value;
+                // querySelector requires escaping brackets in attribute values.
+                var el = form.querySelector('[name="' + field + '"]');
+
+                if (el && el.tagName === 'SELECT') {
+                    // Deselect the matching option in the (hidden) native select.
+                    Array.from(el.options).forEach(function (opt) {
+                        if (opt.value === value) opt.selected = false;
+                    });
+                } else if (el) {
+                    el.value = '';
+                }
+                form.submit();
+            });
+
+            chip.appendChild(btn);
+        });
+    }
+
+    document.addEventListener('DOMContentLoaded', function () {
+        document.querySelectorAll('select.multiselect-search').forEach(buildWidget);
+        initFilterChips();
+    });
+})();

--- a/public/style.css
+++ b/public/style.css
@@ -164,3 +164,173 @@ button, input, select {
 .tooltip-inner {
     text-align: left;
 }
+
+.nodes-cell {
+    word-break: break-word;
+    max-width: 220px;
+}
+
+/* --- Active filter chip bar --- */
+
+.active-filter-chips {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 6px;
+    margin-bottom: 12px;
+}
+
+.filter-chips-label {
+    font-weight: 600;
+}
+
+.filter-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+    background-color: #e9ecef;
+    border: 1px solid #ced4da;
+    border-radius: 20px;
+    padding: 3px 10px;
+    font-size: 0.85rem;
+}
+
+/* Added by JS — not visible without JS */
+.filter-chip-remove {
+    background: none;
+    border: none;
+    padding: 0 2px;
+    cursor: pointer;
+    font-size: 1rem;
+    line-height: 1;
+    color: #6c757d;
+}
+
+.filter-chip-remove:hover {
+    color: #dc3545;
+}
+
+/* --- Searchable multi-select widget (multiselect.js) --- */
+
+.ms-widget {
+    position: relative;
+    width: 100%;
+    font-size: 1rem; /* match native <select> which gets 1rem via button/input/select rule */
+}
+
+/* Mimics a form-control input box; contains chips + search field. */
+.ms-control {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 4px;
+    cursor: text;
+    min-height: 44px;
+    padding: 4px 8px;
+    height: auto; /* override Bootstrap's fixed height */
+}
+
+.ms-chips {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px;
+}
+
+.ms-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    background-color: #0d6efd;
+    color: #fff;
+    border-radius: 4px;
+    padding: 2px 6px;
+    font-size: 0.85rem;
+    white-space: nowrap;
+}
+
+.ms-chip-remove {
+    background: none;
+    border: none;
+    color: #fff;
+    cursor: pointer;
+    padding: 0 2px;
+    font-size: 1rem;
+    line-height: 1;
+}
+
+.ms-search {
+    flex: 1;
+    min-width: 80px;
+    border: none;
+    outline: none;
+    padding: 2px 4px;
+    font-size: 1rem;
+    background: transparent;
+}
+
+/* Dropdown panel */
+.ms-dropdown {
+    display: none;
+    position: absolute;
+    top: 100%;
+    left: 0;
+    right: 0;
+    z-index: 1050;
+    background: #fff;
+    border: 1px solid #dee2e6;
+    border-radius: 4px;
+    max-height: 220px;
+    overflow-y: auto;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.12);
+    font-size: 1rem;
+}
+
+.ms-dropdown.ms-open {
+    display: block;
+}
+
+.ms-options {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}
+
+.ms-option {
+    padding: 8px 12px;
+    cursor: pointer;
+}
+
+.ms-option:hover {
+    background-color: #f0f4ff;
+}
+
+/* Highlight already-selected items in the dropdown. */
+.ms-option.ms-selected {
+    background-color: #cfe2ff;
+    font-weight: 600;
+}
+
+.ms-option.ms-selected:hover {
+    background-color: #b6d4fe;
+}
+
+.ms-option.ms-no-results {
+    color: #6c757d;
+    cursor: default;
+    font-style: italic;
+}
+
+.ms-optgroup-label {
+    padding: 6px 12px 2px;
+    font-size: 0.75rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    color: #6c757d;
+    cursor: default;
+    letter-spacing: 0.05em;
+}
+
+.ms-option.ms-disabled {
+    color: #adb5bd;
+    cursor: default;
+}

--- a/public/style.css
+++ b/public/style.css
@@ -334,3 +334,22 @@ button, input, select {
     color: #adb5bd;
     cursor: default;
 }
+
+.filter-chip.state-fail    { background-color: #ffe4e4; border-color: #f5c6cb; }
+.filter-chip.state-success { background-color: #e4ffec; border-color: #b7e4c7; }
+.filter-chip.state-other   { background-color: #fff8d0; border-color: #ffe58f; }
+
+.ms-option.state-fail                        { background-color: #fff0f0; }
+.ms-option.state-fail:hover                  { background-color: #ffe4e4; }
+.ms-option.state-fail.ms-selected            { background-color: #ffe0e0; }
+.ms-option.state-fail.ms-selected:hover      { background-color: #ffd5d5; }
+
+.ms-option.state-success                     { background-color: #f0fff4; }
+.ms-option.state-success:hover               { background-color: #e4ffec; }
+.ms-option.state-success.ms-selected         { background-color: #dcffe8; }
+.ms-option.state-success.ms-selected:hover   { background-color: #d0ffde; }
+
+.ms-option.state-other                       { background-color: #fffde7; }
+.ms-option.state-other:hover                 { background-color: #fff8d0; }
+.ms-option.state-other.ms-selected           { background-color: #fff5c0; }
+.ms-option.state-other.ms-selected:hover     { background-color: #fff0b0; }

--- a/templates/job_filter_form.html
+++ b/templates/job_filter_form.html
@@ -96,7 +96,7 @@
         <p class="mt-2 mb-3 text-muted">Empty fields are ignored.</p>
 
         <div class="row mb-3">
-            <button type="reset" class="btn btn-secondary col-sm-4 mt-3">Reset</button>
+            <a href="?action=job_history" class="btn btn-secondary col-sm-4 mt-3">Reset</a>
             <div class="col-sm-1"></div>
             <button type="submit" class="btn btn-primary col-sm-7 mt-3">Filter</button>
         </div>

--- a/templates/job_filter_form.html
+++ b/templates/job_filter_form.html
@@ -8,6 +8,7 @@
                     type="datetime-local"
                     id="time_min"
                     name="form_time_min"
+                    class="form-control d-inline-block w-auto"
                     value="{{TIME_MIN_VALUE}}"
                     min="1970-01-01T00:00"
                     max="2033-12-31T23:59"
@@ -17,10 +18,11 @@
                     type="datetime-local"
                     id="time_max"
                     name="form_time_max"
+                    class="form-control d-inline-block w-auto"
                     value="{{TIME_MAX_VALUE}}"
                     min="1970-01-01T00:00"
                     max="2033-12-31T23:59"
-            /> (default: today midnight to now)
+            /> <span class="text-muted">(default: today midnight to now)</span>
         </div>
 
         <button class="btn btn-primary" type="button" data-bs-toggle="collapse" data-bs-target="#collapsefilter"
@@ -28,106 +30,75 @@
             Show/Hide more
         </button>
 
-        <div class="collapse" id="collapsefilter">
+        <div class="collapse mt-2" id="collapsefilter">
             <div class="card card-body">
+                <div class="row">
+                    <div class="col-md-6 form-outline mb-4">
+                        <label for="form_account">Account:</label>
+                        <select class="form-control multiselect-search" name="form_account[]" id="form_account" multiple>
+                            {{ACCOUNT_SELECTS}}
+                        </select>
+                    </div>
 
-                <div class="form-outline mb-4">
-                    <label for="form_cluster">Cluster:</label>
-                    <input type="text"
-                           name="form_cluster"
-                           id="form_cluster"
-                           class="form-control"
-                           value="{{CLUSTER}}"
-                           readonly>
+                    <div class="col-md-6 form-outline mb-4">
+                        <label for="form_partition">Partition:</label>
+                        <select class="form-control multiselect-search" name="form_partition[]" id="form_partition" multiple>
+                            {{PARTITION_SELECTS}}
+                        </select>
+                    </div>
                 </div>
 
-                <div class="form-outline mb-4">
-                    <label for="form_account">Account:</label>
-                    <select class="form-multi-select form-control" name="form_account" id="form_account">
-                        {{ACCOUNT_SELECTS}}
-                    </select>
+                <div class="row">
+                    <div class="col-md-6 form-outline mb-4">
+                        <label for="form_user">User:</label>
+                        <select class="form-control multiselect-search" name="form_user[]" id="form_user" multiple>
+                            {{USER_SELECTS}}
+                        </select>
+                    </div>
+
+                    <div class="col-md-6 form-outline mb-4">
+                        <label for="form_nodename">Node name:</label>
+                        <select class="form-control multiselect-search" name="form_nodename[]" id="form_nodename" multiple>
+                            {{NODE_SELECTS}}
+                        </select>
+                    </div>
                 </div>
 
-                <div class="form-outline mb-4">
-                    <label for="job_name">Job name:</label>
-                    <input type="text"
-                           name="form_job_name"
-                           id="job_name"
-                           class="form-control"
-                           value="{{JOB_NAME}}">
-                </div>
+                <div class="row">
+                    <div class="col-md-6 form-outline mb-4">
+                        <label for="job_name">Job name:</label>
+                        <input type="text"
+                               name="form_job_name"
+                               id="job_name"
+                               class="form-control"
+                               value="{{JOB_NAME}}">
+                    </div>
 
-                <div class="form-outline mb-4">
-                    <label for="constraints">Constraints:</label>
-                    <input type="text"
-                           name="form_constraints"
-                           id="constraints"
-                           class="form-control"
-                           value="{{CONSTRAINTS}}">
-                </div>
-
-                <div class="form-outline mb-4">
-                    <label for="form_user">User:</label>
-                    <select class="form-multi-select form-control" name="form_user" id="form_user">
-                        {{USER_SELECTS}}
-                    </select>
-                </div>
-
-                <div class="form-outline mb-4">
-                    <label for="form_nodename">Node name:</label>
-                    <select class="form-multi-select form-control" name="form_nodename" id="form_nodename">
-                        {{NODE_SELECTS}}
-                    </select>
+                    <div class="col-md-6 form-outline mb-4">
+                        <label for="constraints">Constraints:</label>
+                        <input type="text"
+                               name="form_constraints"
+                               id="constraints"
+                               class="form-control"
+                               value="{{CONSTRAINTS}}">
+                    </div>
                 </div>
 
                 <div class="form-outline mb-4">
                     <label for="form_state">State:</label>
-                    <select class="form-multi-select form-control" name="form_state" id="form_state">
-                        <option selected></option>
-                        <optgroup label="Fail states">
-                            <option value="BOOT_FAIL">BOOT_FAIL</option>
-                            <option value="CANCELLED">CANCELLED</option>
-                            <option value="DEADLINE">DEADLINE</option>
-                            <option value="FAILED">FAILED</option>
-                            <option value="NODE_FAIL">NODE_FAIL</option>
-                            <option value="OUT_OF_MEMORY">OUT_OF_MEMORY</option>
-                            <option value="STOPPED">STOPPED</option>
-                            <option value="TIMEOUT">TIMEOUT</option>
-                            <option value="RESV_DEL_HOLD" disabled>RESV_DEL_HOLD</option>
-                        </optgroup>
-                        <optgroup label="Success states">
-                            <option value="COMPLETED">COMPLETED</option>
-                            <option value="COMPLETING">COMPLETING</option>
-                            <option value="CONFIGURING">CONFIGURING</option>
-                            <option value="RUNNING">RUNNING</option>
-                        </optgroup>
-                        <optgroup label="Other states">
-                            <option value="PENDING">PENDING</option>
-                            <option value="PREEMPTED">PREEMPTED</option>
-                            <option value="SUSPENDED">SUSPENDED</option>
-                            <option value="REQUEUED">REQUEUED</option>
-                            <option value="REQUEUE_FED" disabled>REQUEUE_FED</option>
-                            <option value="REQUEUE_HOLD" disabled>REQUEUE_HOLD</option>
-                            <option value="RESIZING" disabled>RESIZING</option>
-                            <option value="REVOKED" disabled>REVOKED</option>
-                            <option value="SIGNALING" disabled>SIGNALING</option>
-                            <option value="SPECIAL_EXIT" disabled>SPECIAL_EXIT</option>
-                            <option value="STAGE_OUT" disabled>STAGE_OUT</option>
-                        </optgroup>
+                    <select class="form-control multiselect-search" name="form_state[]" id="form_state" multiple>
+                        {{STATE_SELECTS}}
                     </select>
                 </div>
-
             </div>
         </div>
 
-        <div class="row mb-3">
-            Empty fields are ignored.
-        </div>
+        <p class="mt-2 mb-3 text-muted">Empty fields are ignored.</p>
 
         <div class="row mb-3">
-            <button type="reset" class="btn btn-secondary col-sm-4" style="margin-top: 1em">Cancel</button>
+            <button type="reset" class="btn btn-secondary col-sm-4 mt-3">Reset</button>
             <div class="col-sm-1"></div>
-            <button type="submit" class="btn btn-primary col-sm-7" style="margin-top: 1em">Filter</button>
+            <button type="submit" class="btn btn-primary col-sm-7 mt-3">Filter</button>
         </div>
     </fieldset>
 </form>

--- a/utils.inc.php
+++ b/utils.inc.php
@@ -8,6 +8,53 @@ namespace utils;
 
 use InvalidArgumentException;
 
+/**
+ * Metadata per state group (label, badge color, CSS class).
+ * Used together with SLURM_JOB_STATES to render optgroups and derive colors/classes.
+ */
+const SLURM_JOB_STATE_GROUP_META = [
+    'Fail states'    => ['color' => '#dc3545', 'css_class' => 'state-fail'],
+    'Success states' => ['color' => '#28a745', 'css_class' => 'state-success'],
+    'Other states'   => ['color' => '#ffc107', 'css_class' => 'state-other'],
+];
+
+/**
+ * Flat state → attribute map. Authoritative source for all state-related
+ * lookups. Color and CSS class are resolved via SLURM_JOB_STATE_GROUP_META.
+ * Used by get_job_state_view(), the filter form, and the active-filter chip bar.
+ *
+ * Structure: state name => [
+ *   'group'    => group label (matches a key in SLURM_JOB_STATE_GROUP_META),
+ *   'disabled' => bool (shown greyed-out in the filter dropdown),
+ * ]
+ */
+const SLURM_JOB_STATES = [
+    'BOOT_FAIL'     => ['group' => 'Fail states',    'disabled' => FALSE],
+    'CANCELLED'     => ['group' => 'Fail states',    'disabled' => FALSE],
+    'DEADLINE'      => ['group' => 'Fail states',    'disabled' => FALSE],
+    'FAILED'        => ['group' => 'Fail states',    'disabled' => FALSE],
+    'NODE_FAIL'     => ['group' => 'Fail states',    'disabled' => FALSE],
+    'OUT_OF_MEMORY' => ['group' => 'Fail states',    'disabled' => FALSE],
+    'STOPPED'       => ['group' => 'Fail states',    'disabled' => FALSE],
+    'TIMEOUT'       => ['group' => 'Fail states',    'disabled' => FALSE],
+    'RESV_DEL_HOLD' => ['group' => 'Fail states',    'disabled' => TRUE],
+    'COMPLETED'     => ['group' => 'Success states', 'disabled' => FALSE],
+    'COMPLETING'    => ['group' => 'Success states', 'disabled' => FALSE],
+    'CONFIGURING'   => ['group' => 'Success states', 'disabled' => FALSE],
+    'RUNNING'       => ['group' => 'Success states', 'disabled' => FALSE],
+    'PENDING'       => ['group' => 'Other states',   'disabled' => FALSE],
+    'PREEMPTED'     => ['group' => 'Other states',   'disabled' => FALSE],
+    'SUSPENDED'     => ['group' => 'Other states',   'disabled' => FALSE],
+    'REQUEUED'      => ['group' => 'Other states',   'disabled' => FALSE],
+    'REQUEUE_FED'   => ['group' => 'Other states',   'disabled' => TRUE],
+    'REQUEUE_HOLD'  => ['group' => 'Other states',   'disabled' => TRUE],
+    'RESIZING'      => ['group' => 'Other states',   'disabled' => TRUE],
+    'REVOKED'       => ['group' => 'Other states',   'disabled' => TRUE],
+    'SIGNALING'     => ['group' => 'Other states',   'disabled' => TRUE],
+    'SPECIAL_EXIT'  => ['group' => 'Other states',   'disabled' => TRUE],
+    'STAGE_OUT'     => ['group' => 'Other states',   'disabled' => TRUE],
+];
+
 function get_date_from_unix_if_defined(array $job_arr, string $param, string $default = 'undefined') : string {
     if(! isset($job_arr[$param])){
         return $default;
@@ -38,26 +85,8 @@ function get_job_state_view(array $job, string $param_name = 'job_state'): strin
 
     $job_state_text = '';
     foreach($job_state_array as $job_state) {
-        $state_color = "#ffc107"; # orange
-        if ($job_state == 'BOOT_FAIL' ||
-            $job_state == 'CANCELLED' ||
-            $job_state == 'DEADLINE' ||
-            $job_state == 'FAILED' ||
-            $job_state == 'NODE_FAIL' ||
-            $job_state == 'OUT_OF_MEMORY' ||
-            $job_state == 'STOPPED' ||
-            $job_state == 'TIMEOUT'
-        ) {
-            $state_color = "#dc3545"; # Red
-        } elseif (
-            $job_state == 'COMPLETED' ||
-            $job_state == 'CONFIGURING' ||
-            $job_state == 'COMPLETING' ||
-            $job_state == 'RUNNING'
-        ) {
-            $state_color = "#28a745"; # green
-        }
-
+        $group = SLURM_JOB_STATES[$job_state]['group'] ?? NULL;
+        $state_color = $group !== NULL ? SLURM_JOB_STATE_GROUP_META[$group]['color'] : '#ffc107';
         $job_state_text .= '<span class="badge" style="background-color: ' . $state_color . '">' . htmlspecialchars($job_state, ENT_QUOTES, 'UTF-8') . '</span> ';
     }
     return $job_state_text;

--- a/view/job.tpl.php
+++ b/view/job.tpl.php
@@ -6,7 +6,7 @@ use TemplateLoader;
 
 function get_slurm_jobinfo(array $query, string $transitive_dependencies = '') : string {
 
-    $contents = '<h3>Job queue information</h3>';
+    $contents = '<h2>Job queue information</h2>';
 
     $job_state_text = \utils\get_job_state_view($query);
     $user = htmlspecialchars($query['user_name'] . " (" . $query['user_id'] . ')', ENT_QUOTES, 'UTF-8');
@@ -60,7 +60,7 @@ function get_slurm_jobinfo(array $query, string $transitive_dependencies = '') :
 
 
 function get_slurmdb_jobinfo(array $query) : string {
-    $contents = '<h3>Slurmdb information</h3>';
+    $contents = '<h2>Slurmdb information</h2>';
 
     $job_state_text = \utils\get_job_state_view($query);
 

--- a/view/job_history.tpl.php
+++ b/view/job_history.tpl.php
@@ -10,17 +10,20 @@ use TemplateLoader;
  * Get options from the filter form.
  * @return array Array of filter options
  *
- * Filter options:
- * - cluster (CSV list)
- * - account (CSV list)
- * - job_name (CSV list)
- * - constraints (CSV list)
- * - exit_code (numeric)
- * - partition (CSV list)
- * - state (CSV state list)
- * - end_time (UNIX timestamp)
- * - node (node string)
- * - users (CSV user list)
+ * Filter options (passed to the API):
+ * - account        (array of strings)
+ * - users          (array of strings)
+ * - partition      (array of strings)
+ * - node           (array of strings)
+ * - state          (array of strings, validated against known Slurm states)
+ * - job_name       (string)
+ * - constraints    (string)
+ * - start_time     (int, UNIX timestamp)
+ * - end_time       (int, UNIX timestamp)
+ *
+ * Other indices:
+ * - start_time_value (string, raw datetime string for form repopulation)
+ * - end_time_value   (string, raw datetime string for form repopulation)
  */
 function get_slurmdb_filter_form_evaluation() : array {
     // BEGIN evaluate filter form
@@ -54,19 +57,24 @@ function get_slurmdb_filter_form_evaluation() : array {
             }
         }
 
-        $user = $_POST['form_user'] ?? '';
-        if($user != ''){
-            $filter['users'] = $user;
+        $user = array_filter(array_map('trim', $_POST['form_user'] ?? []));
+        if (!empty($user)) {
+            $filter['users'] = array_values($user);
         }
 
-        $account = $_POST['form_account'] ?? '';
-        if($account != ''){
-            $filter['account'] = $account;
+        $account = array_filter(array_map('trim', $_POST['form_account'] ?? []));
+        if (!empty($account)) {
+            $filter['account'] = array_values($account);
         }
 
-        $node = $_POST['form_nodename'] ?? '';
-        if($node != ''){
-            $filter['node'] = $node;
+        $partition = array_filter(array_map('trim', $_POST['form_partition'] ?? []));
+        if (!empty($partition)) {
+            $filter['partition'] = array_values($partition);
+        }
+
+        $node = array_filter(array_map('trim', $_POST['form_nodename'] ?? []));
+        if (!empty($node)) {
+            $filter['node'] = array_values($node);
         }
 
         $job_name = $_POST['form_job_name'] ?? '';
@@ -79,7 +87,6 @@ function get_slurmdb_filter_form_evaluation() : array {
             $filter['constraints'] = $constraints;
         }
 
-        $state = $_POST['form_state'] ?? '';
         $valid_states = [
             'BOOT_FAIL', 'CANCELLED', 'DEADLINE', 'FAILED', 'NODE_FAIL',
             'OUT_OF_MEMORY', 'STOPPED', 'TIMEOUT', 'COMPLETED', 'COMPLETING',
@@ -87,7 +94,8 @@ function get_slurmdb_filter_form_evaluation() : array {
             'REQUEUED', 'RESV_DEL_HOLD', 'REQUEUE_FED', 'REQUEUE_HOLD',
             'RESIZING', 'REVOKED', 'SPECIAL_EXIT', 'STAGE_OUT',
         ];
-        if(in_array($state, $valid_states, true)){
+        $state = array_values(array_filter($_POST['form_state'] ?? [], fn($s) => in_array($s, $valid_states, TRUE)));
+        if (!empty($state)) {
             $filter['state'] = $state;
         }
     }
@@ -97,65 +105,97 @@ function get_slurmdb_filter_form_evaluation() : array {
 }
 
 
-function get_slurmdb_filter_form(array $filter, array $accounts, array $users, array $nodes) : string {
+function get_slurmdb_filter_form(array $filter, array $accounts, array $users, array $nodes, array $partitions) : string {
 
     // Accounts field
+    $selected_accounts = array_flip($filter['account'] ?? []);
     $account_list = '';
-    $selected = FALSE;
-    foreach ($accounts as $account){
+    foreach ($accounts as $account) {
+        if ($account === 'root') continue;
         $account_e = htmlspecialchars($account, ENT_QUOTES, 'UTF-8');
-        if(isset($filter['account']) && $filter['account'] == $account) {
-            $account_list .= '<option value="' . $account_e . '" selected>' . $account_e . '</option>';
-            $selected = TRUE;
-        }
-        else {
-            $account_list .= '<option value="' . $account_e . '">'. $account_e . '</option>';
-        }
+        $sel = isset($selected_accounts[$account]) ? ' selected' : '';
+        $account_list .= '<option value="' . $account_e . '"' . $sel . '>' . $account_e . '</option>';
     }
-    if(! $selected)
-        $account_list = '<option selected></option>' . $account_list;
-    else
-        $account_list = '<option></option>' . $account_list;
 
     // Users field
+    $selected_users = array_flip($filter['users'] ?? []);
     $users_list = '';
-    $selected = FALSE;
-    foreach ($users as $user){
+    foreach ($users as $user) {
+        if ($user === 'root') continue;
         $user_e = htmlspecialchars($user, ENT_QUOTES, 'UTF-8');
-        if(isset($filter['users']) && $filter['users'] == $user) {
-            $users_list .= '<option value="' . $user_e . '" selected>'. $user_e . '</option>';
-            $selected = TRUE;
-        }
-        else {
-            $users_list .= '<option value="' . $user_e . '">'. $user_e . '</option>';
-        }
+        $sel = isset($selected_users[$user]) ? ' selected' : '';
+        $users_list .= '<option value="' . $user_e . '"' . $sel . '>' . $user_e . '</option>';
     }
-    if(! $selected)
-        $users_list = '<option selected></option>' . $users_list;
-    else
-        $users_list = '<option></option>' . $users_list;
+
+    // Partitions field
+    $selected_partitions = array_flip($filter['partition'] ?? []);
+    $partition_list = '';
+    foreach ($partitions as $partition) {
+        $partition_e = htmlspecialchars($partition, ENT_QUOTES, 'UTF-8');
+        $sel = isset($selected_partitions[$partition]) ? ' selected' : '';
+        $partition_list .= '<option value="' . $partition_e . '"' . $sel . '>' . $partition_e . '</option>';
+    }
 
     // Nodes field
+    $selected_nodes = array_flip($filter['node'] ?? []);
     $node_list = '';
-    $selected = FALSE;
-    foreach ($nodes as $node){
+    foreach ($nodes as $node) {
         $node_e = htmlspecialchars($node, ENT_QUOTES, 'UTF-8');
-        if(isset($filter['node']) && $filter['node'] == $node) {
-            $node_list .= '<option value="' . $node_e . '" selected>' . $node_e . '</option>';
-            $selected = TRUE;
-        }
-        else {
-            $node_list .= '<option value="' . $node_e . '">'. $node_e . '</option>';
-        }
+        $sel = isset($selected_nodes[$node]) ? ' selected' : '';
+        $node_list .= '<option value="' . $node_e . '"' . $sel . '>' . $node_e . '</option>';
     }
-    if(! $selected)
-        $node_list = '<option selected></option>' . $node_list;
-    else
-        $node_list = '<option></option>' . $node_list;
+
+    // State field — options are hardcoded (well-known Slurm states).
+    $state_groups = [
+        'Fail states' => [
+            'BOOT_FAIL'     => FALSE,
+            'CANCELLED'     => FALSE,
+            'DEADLINE'      => FALSE,
+            'FAILED'        => FALSE,
+            'NODE_FAIL'     => FALSE,
+            'OUT_OF_MEMORY' => FALSE,
+            'STOPPED'       => FALSE,
+            'TIMEOUT'       => FALSE,
+            'RESV_DEL_HOLD' => TRUE,  // disabled
+        ],
+        'Success states' => [
+            'COMPLETED'  => FALSE,
+            'COMPLETING' => FALSE,
+            'CONFIGURING'=> FALSE,
+            'RUNNING'    => FALSE,
+        ],
+        'Other states' => [
+            'PENDING'      => FALSE,
+            'PREEMPTED'    => FALSE,
+            'SUSPENDED'    => FALSE,
+            'REQUEUED'     => FALSE,
+            'REQUEUE_FED'  => TRUE,
+            'REQUEUE_HOLD' => TRUE,
+            'RESIZING'     => TRUE,
+            'REVOKED'      => TRUE,
+            'SIGNALING'    => TRUE,
+            'SPECIAL_EXIT' => TRUE,
+            'STAGE_OUT'    => TRUE,
+        ],
+    ];
+    $selected_states = array_flip($filter['state'] ?? []);
+    $state_list = '';
+    foreach ($state_groups as $group_label => $states) {
+        $group_e = htmlspecialchars($group_label, ENT_QUOTES, 'UTF-8');
+        $state_list .= '<optgroup label="' . $group_e . '">';
+        foreach ($states as $val => $disabled) {
+            $val_e = htmlspecialchars($val, ENT_QUOTES, 'UTF-8');
+            $sel = isset($selected_states[$val]) ? ' selected' : '';
+            $dis = $disabled ? ' disabled' : '';
+            $state_list .= '<option value="' . $val_e . '"' . $sel . $dis . '>' . $val_e . '</option>';
+        }
+        $state_list .= '</optgroup>';
+    }
 
     $templateBuilder = new TemplateLoader("job_filter_form.html");
-    $templateBuilder->setParam("CLUSTER", config("CLUSTER_NAME"));
     $templateBuilder->setParam("ACCOUNT_SELECTS", $account_list);
+    $templateBuilder->setParam("PARTITION_SELECTS", $partition_list);
+    $templateBuilder->setParam("STATE_SELECTS", $state_list);
     $templateBuilder->setParam("JOB_NAME", htmlspecialchars($filter['job_name'] ?? '', ENT_QUOTES, 'UTF-8'));
     $templateBuilder->setParam("CONSTRAINTS", htmlspecialchars($filter['constraints'] ?? '', ENT_QUOTES, 'UTF-8'));
     $templateBuilder->setParam("USER_SELECTS", $users_list);
@@ -167,8 +207,43 @@ function get_slurmdb_filter_form(array $filter, array $accounts, array $users, a
 }
 
 
-function get_filtered_jobs_from_slurmdb(array $jobs) : string {
-    $contents = '<div>Found <span style="font-weight: bold">' . count($jobs) . ' jobs</span>.</div>';
+function get_filtered_jobs_from_slurmdb(array $jobs, array $filter = []) : string {
+    // Active filter chips — JS adds the × removal buttons.
+    $chip_configs = [
+        // filter key => [display label, form field name, is multi-select]
+        'account'     => ['Account',      'form_account',    TRUE],
+        'users'       => ['User',         'form_user',       TRUE],
+        'partition'   => ['Partition',    'form_partition',  TRUE],
+        'node'        => ['Node',         'form_nodename',   TRUE],
+        'state'       => ['State',        'form_state',      TRUE],
+        'job_name'    => ['Job name',     'form_job_name',   FALSE],
+        'constraints' => ['Constraints',  'form_constraints',FALSE],
+    ];
+    $chips = '';
+    foreach ($chip_configs as $key => [$label, $field, $multi]) {
+        if (!isset($filter[$key])) continue;
+        foreach (($multi ? $filter[$key] : [$filter[$key]]) as $val) {
+            $val_e   = htmlspecialchars($val,   ENT_QUOTES, 'UTF-8');
+            $field_e = htmlspecialchars($multi ? $field . '[]' : $field, ENT_QUOTES, 'UTF-8');
+            $label_e = htmlspecialchars($label, ENT_QUOTES, 'UTF-8');
+            $chips .= '<span class="filter-chip" data-field="' . $field_e . '" data-value="' . $val_e . '">'
+                    . $label_e . ': <strong>' . $val_e . '</strong></span>';
+        }
+    }
+    if (isset($filter['start_time_value'])) {
+        $val_e  = htmlspecialchars($filter['start_time_value'], ENT_QUOTES, 'UTF-8');
+        $chips .= '<span class="filter-chip" data-field="form_time_min" data-value="">From: <strong>' . $val_e . '</strong></span>';
+    }
+    if (isset($filter['end_time_value'])) {
+        $val_e  = htmlspecialchars($filter['end_time_value'], ENT_QUOTES, 'UTF-8');
+        $chips .= '<span class="filter-chip" data-field="form_time_max" data-value="">To: <strong>' . $val_e . '</strong></span>';
+    }
+
+    $contents = $chips !== ''
+        ? '<div class="active-filter-chips"><span class="filter-chips-label">Active filters:</span> ' . $chips . '</div>'
+        : '';
+
+    $contents .= '<div>Found <span style="font-weight: bold">' . count($jobs) . ' jobs</span>.</div>';
 
     $contents .= <<<EOF
 <div id="jobtable-table" class="table-responsive tableFixHead">
@@ -191,6 +266,8 @@ function get_filtered_jobs_from_slurmdb(array $jobs) : string {
         <tbody>
 EOF;
 
+    $active_states = ['PENDING', 'RUNNING', 'COMPLETING', 'CONFIGURING', 'SUSPENDED', 'REQUEUED'];
+
     foreach( $jobs as $job ) {
 
         $contents .= "<tr>";
@@ -206,9 +283,42 @@ EOF;
         $contents .=    "<td>" . $job['time_elapsed'] . "</td>";
         $contents .=    "<td>" . $job['time_limit'] . "</td>";
 
-        $contents .=    "<td>" . htmlspecialchars($job['nodes'], ENT_QUOTES, 'UTF-8') . "</td>";
-        $contents .=    '<td><a href="?action=job&job_id=' . $job['job_id'] . '">[Details]</a></td>';
+        // Zero-width spaces after commas let the browser wrap at natural break points
+        // without adding visible characters (works for both "a,b,c" and "n[1-5,8]").
+        $nodes_e = str_replace(',', ',&#8203;', htmlspecialchars($job['nodes'], ENT_QUOTES, 'UTF-8'));
+        $contents .=    "<td class='nodes-cell'>" . $nodes_e . "</td>";
 
+        $contents .= '<td><div class="btn-group">';
+        $contents .= '<a href="?action=job&job_id=' . $job['job_id'] . '" class="btn btn-info" type="button">Details</a>';
+        $contents .= '<button type="button" class="btn btn-danger dropdown-toggle dropdown-toggle-split"'
+                   . ' data-bs-toggle="dropdown" aria-expanded="false">'
+                   . '<span class="visually-hidden">Toggle Dropdown</span></button>';
+
+        if (\client\utils\jwt\JwtAuthentication::is_supported() && !empty(array_intersect($job['job_state'], $active_states))) {
+            $contents .= '<ul class="dropdown-menu">'
+                       . '<li><a class="dropdown-item" href="?action=cancel-job&job_id=' . $job['job_id'] . '">Cancel job</a></li>'
+                       . '<li><a class="dropdown-item" href="?action=edit-job&job_id=' . $job['job_id'] . '">Edit job</a></li>'
+                       . '</ul>';
+        } elseif (!\client\utils\jwt\JwtAuthentication::is_supported()) {
+            $tooltip = 'This feature is not supported by the current configuration.';
+            $contents .= '<ul class="dropdown-menu"><li>'
+                       . '<span class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right" title="' . $tooltip . '">'
+                       . '<a class="dropdown-item disabled" href="?action=cancel-job&job_id=' . $job['job_id'] . '" aria-disabled="true">Cancel job</a></span>'
+                       . '<span class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right" title="' . $tooltip . '">'
+                       . '<a class="dropdown-item disabled" href="?action=edit-job&job_id=' . $job['job_id'] . '" aria-disabled="true">Edit job</a></span>'
+                       . '</li></ul>';
+        } else {
+            $tooltip = 'Job is no longer active.';
+            $contents .= '<ul class="dropdown-menu"><li>'
+                       . '<span class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right" title="' . $tooltip . '">'
+                       . '<a class="dropdown-item disabled" href="?action=cancel-job&job_id=' . $job['job_id'] . '" aria-disabled="true">Cancel job</a></span>'
+                       . '<span class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right" title="' . $tooltip . '">'
+                       . '<a class="dropdown-item disabled" href="?action=edit-job&job_id=' . $job['job_id'] . '" aria-disabled="true">Edit job</a></span>'
+                       . '</li></ul>';
+        }
+
+        $contents .= '</div></td>';
+        $contents .= '</tr>';
     }
     $contents .= <<<EOF
         </tbody>

--- a/view/job_history.tpl.php
+++ b/view/job_history.tpl.php
@@ -87,14 +87,7 @@ function get_slurmdb_filter_form_evaluation() : array {
             $filter['constraints'] = $constraints;
         }
 
-        $valid_states = [
-            'BOOT_FAIL', 'CANCELLED', 'DEADLINE', 'FAILED', 'NODE_FAIL',
-            'OUT_OF_MEMORY', 'STOPPED', 'TIMEOUT', 'COMPLETED', 'COMPLETING',
-            'CONFIGURING', 'RUNNING', 'PENDING', 'PREEMPTED', 'SUSPENDED',
-            'REQUEUED', 'RESV_DEL_HOLD', 'REQUEUE_FED', 'REQUEUE_HOLD',
-            'RESIZING', 'REVOKED', 'SPECIAL_EXIT', 'STAGE_OUT',
-        ];
-        $state = array_values(array_filter($_POST['form_state'] ?? [], fn($s) => in_array($s, $valid_states, TRUE)));
+        $state = array_values(array_filter($_POST['form_state'] ?? [], fn($s) => isset(\utils\SLURM_JOB_STATES[$s])));
         if (!empty($state)) {
             $filter['state'] = $state;
         }
@@ -145,49 +138,19 @@ function get_slurmdb_filter_form(array $filter, array $accounts, array $users, a
         $node_list .= '<option value="' . $node_e . '"' . $sel . '>' . $node_e . '</option>';
     }
 
-    // State field — options are hardcoded (well-known Slurm states).
-    $state_groups = [
-        'Fail states' => [
-            'BOOT_FAIL'     => FALSE,
-            'CANCELLED'     => FALSE,
-            'DEADLINE'      => FALSE,
-            'FAILED'        => FALSE,
-            'NODE_FAIL'     => FALSE,
-            'OUT_OF_MEMORY' => FALSE,
-            'STOPPED'       => FALSE,
-            'TIMEOUT'       => FALSE,
-            'RESV_DEL_HOLD' => TRUE,  // disabled
-        ],
-        'Success states' => [
-            'COMPLETED'  => FALSE,
-            'COMPLETING' => FALSE,
-            'CONFIGURING'=> FALSE,
-            'RUNNING'    => FALSE,
-        ],
-        'Other states' => [
-            'PENDING'      => FALSE,
-            'PREEMPTED'    => FALSE,
-            'SUSPENDED'    => FALSE,
-            'REQUEUED'     => FALSE,
-            'REQUEUE_FED'  => TRUE,
-            'REQUEUE_HOLD' => TRUE,
-            'RESIZING'     => TRUE,
-            'REVOKED'      => TRUE,
-            'SIGNALING'    => TRUE,
-            'SPECIAL_EXIT' => TRUE,
-            'STAGE_OUT'    => TRUE,
-        ],
-    ];
+    // State field — built from the authoritative SLURM_JOB_STATES constant.
     $selected_states = array_flip($filter['state'] ?? []);
     $state_list = '';
-    foreach ($state_groups as $group_label => $states) {
+    foreach (\utils\SLURM_JOB_STATE_GROUP_META as $group_label => $group_meta) {
         $group_e = htmlspecialchars($group_label, ENT_QUOTES, 'UTF-8');
         $state_list .= '<optgroup label="' . $group_e . '">';
-        foreach ($states as $val => $disabled) {
-            $val_e = htmlspecialchars($val, ENT_QUOTES, 'UTF-8');
-            $sel = isset($selected_states[$val]) ? ' selected' : '';
-            $dis = $disabled ? ' disabled' : '';
-            $state_list .= '<option value="' . $val_e . '"' . $sel . $dis . '>' . $val_e . '</option>';
+        foreach (\utils\SLURM_JOB_STATES as $val => $attrs) {
+            if ($attrs['group'] !== $group_label) continue;
+            $val_e     = htmlspecialchars($val, ENT_QUOTES, 'UTF-8');
+            $sel       = isset($selected_states[$val]) ? ' selected' : '';
+            $dis       = $attrs['disabled'] ? ' disabled' : '';
+            $cls_attr  = ' class="' . $group_meta['css_class'] . '"';
+            $state_list .= '<option value="' . $val_e . '"' . $sel . $dis . $cls_attr . '>' . $val_e . '</option>';
         }
         $state_list .= '</optgroup>';
     }
@@ -223,10 +186,14 @@ function get_filtered_jobs_from_slurmdb(array $jobs, array $filter = []) : strin
     foreach ($chip_configs as $key => [$label, $field, $multi]) {
         if (!isset($filter[$key])) continue;
         foreach (($multi ? $filter[$key] : [$filter[$key]]) as $val) {
-            $val_e   = htmlspecialchars($val,   ENT_QUOTES, 'UTF-8');
-            $field_e = htmlspecialchars($multi ? $field . '[]' : $field, ENT_QUOTES, 'UTF-8');
-            $label_e = htmlspecialchars($label, ENT_QUOTES, 'UTF-8');
-            $chips .= '<span class="filter-chip" data-field="' . $field_e . '" data-value="' . $val_e . '">'
+            $val_e      = htmlspecialchars($val,   ENT_QUOTES, 'UTF-8');
+            $field_e    = htmlspecialchars($multi ? $field . '[]' : $field, ENT_QUOTES, 'UTF-8');
+            $label_e    = htmlspecialchars($label, ENT_QUOTES, 'UTF-8');
+            $extra_class = '';
+            if ($key === 'state' && isset(\utils\SLURM_JOB_STATES[$val])) {
+                $extra_class = ' ' . \utils\SLURM_JOB_STATE_GROUP_META[\utils\SLURM_JOB_STATES[$val]['group']]['css_class'];
+            }
+            $chips .= '<span class="filter-chip' . $extra_class . '" data-field="' . $field_e . '" data-value="' . $val_e . '">'
                     . $label_e . ': <strong>' . $val_e . '</strong></span>';
         }
     }


### PR DESCRIPTION
### Filter form (`templates/job_filter_form.html`, `view/job_history.tpl.php`)

- Replace single-select dropdowns for Account, User, Partition, Node, and State with multi-select dropdowns, allowing multiple values to be selected at once.
- Remove the Cluster field (read-only, no filter effect).
- Exclude `root` from the Account and User dropdowns.
- Add Partition as a new filter field.
- Replace state as a multi-select filter field (even though the filtering is still sometimes done on the client-side).
- Layout improvements:
  - Two-column layout for Account/Partition, User/Node, Job name/Constraints inside the collapse area.
  - Rename "Cancel" button to "Reset" and fix it.
  - Minor improvements.
- Filter values are stored as PHP arrays throughout (no intermediate CSV strings).
- New custom searchable multi-select widget (`multiselect.js`) that progressively enhances any `<select multiple class="multiselect-search">` element. Without JavaScript, the native multi-select remains fully functional.
- The native `<select>` is kept in the DOM (hidden) and is authoritative for form submission; the widget only mirrors its state visually.
- A chip bar above the results table shows all currently active filters.
  - With JavaScript, each chip has a × button that removes that individual filter value and immediately resubmits the form.
  - Without JavaScript, the chips are shown as read-only badges.

### Job history table (`view/job_history.tpl.php`)
- Node list column: zero-width spaces inserted after commas so the browser can wrap at natural break points without adding visible characters; `word-break: break-word` applied via `.nodes-cell`.
- Add Details/Edit/Cancel action buttons (same dropdown pattern as the queue view). Details is always active; Edit and Cancel are disabled (with tooltip) when JWT authentication is not configured or the job is no longer in an active state.

### Bug fixes
- Fix missing `</tr>` closing tag on each row at job history table.

- **`client/AbstractClient.inc.php`** — The time limit column in the job history table sometimes showed "inf" and sometimes "infinite" for unlimited jobs.

### API layer (`client/AbstractClient.inc.php`, `client/Client.inc.php`)

- Multi-value filter fields (users, account, partition, node) are sent as repeated parameters (`&users=a&users=b`) instead of a single CSV string, matching slurmrestd's actual array serialization behavior.
- Add `get_partition_list()` to the `Client` interface and implement it in `AbstractClient`.
- Refactor `_issue12_bugfix_post_request_filtering()` to accept an array of states instead of a single string, and use it uniformly for both single broken states and multiple state selections.
- `$valid_states` is now a global array in `\utils`

### Misc
- Some CSS