### PR TITLE
Minor improvement in the job table (job menu)

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -34,6 +34,7 @@ require_once __DIR__ . '/../client/utils/DependencyResolver.inc.php';
 require_once __DIR__ . '/../auth/auth.inc.php';
 require_once __DIR__ . '/../utils.inc.php';
 
+require_once __DIR__ . '/../view/job_actions_dropdown.tpl.php';
 require_once __DIR__ . '/../view/login.tpl.php';
 require_once __DIR__ . '/../view/maintenances.tpl.php';
 require_once __DIR__ . '/../view/usage.tpl.php';

--- a/view/job.tpl.php
+++ b/view/job.tpl.php
@@ -15,16 +15,27 @@ function get_slurm_jobinfo(array $query, string $transitive_dependencies = '') :
     $contents = '<h2>Job queue information</h2>';
 
     $job_state_text = \utils\get_job_state_view($query);
-    $user = htmlspecialchars($query['user_name'] . " (" . $query['user_id'] . ')', ENT_QUOTES, 'UTF-8');
-    $user_name = htmlspecialchars($query['user_name'], ENT_QUOTES, 'UTF-8');
+    // Note: $user can be an empty string if the user does not exist on the host where slurmrestd is running.
+    if( ! empty($query['user_name']) ){
+        $user = htmlspecialchars($query['user_name'] . " (" . $query['user_id'] . ')', ENT_QUOTES, 'UTF-8');
+        $user_link = '<a href="?action=users&user_name='. htmlspecialchars($query['user_name'], ENT_QUOTES, 'UTF-8')
+                     . '" title="Note: Currently, only admins can view this user details.">'
+                     .         $user
+                     . '</a>';
+    }
+    else {
+        // We did not get a username, so display the user id only ...
+        $user = $query['user_id'];
+        $user_link = $user;
+    }
+
     $group = htmlspecialchars($query['group_name'] . " (" . $query['group_id'] . ')', ENT_QUOTES, 'UTF-8');
     $requeue = $query['requeue'] ? 'allowed' : 'not allowed';
 
     $templateBuilder = new TemplateLoader("jobinfo.html");
     $templateBuilder->setParam("JOBID",             $query['job_id']                    );
     $templateBuilder->setParam("JOBNAME",           htmlspecialchars($query['job_name'], ENT_QUOTES, 'UTF-8'));
-    $templateBuilder->setParam("USER",              $user                               );
-    $templateBuilder->setParam("USER_NAME",         $user_name                          );
+    $templateBuilder->setParam("USER",              $user_link                          );
     $templateBuilder->setParam("GROUP",             $group                              );
     $templateBuilder->setParam("ACCOUNT",           htmlspecialchars($query['account'], ENT_QUOTES, 'UTF-8'));
     $templateBuilder->setParam("PARTITIONS",        htmlspecialchars($query['partition'], ENT_QUOTES, 'UTF-8'));

--- a/view/job_actions_dropdown.tpl.php
+++ b/view/job_actions_dropdown.tpl.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace view\actions;
+
+/**
+ * Renders the Cancel/Edit dropdown menu for a job action button group.
+ * @param int $job_id Job ID used in action URLs
+ * @param bool $disabled Whether the buttons should be rendered as disabled
+ * @param string $tooltip Tooltip shown on disabled buttons; ignored when $disabled is FALSE
+ * @return string Rendered HTML for the dropdown menu
+ */
+function render_job_action_dropdown(int $job_id, bool $disabled, string $tooltip = '') : string {
+    if (!$disabled) {
+        return '<ul class="dropdown-menu">'
+             . '<li><a class="dropdown-item" href="?action=cancel-job&job_id=' . $job_id . '">Cancel job</a></li>'
+             . '<li><a class="dropdown-item" href="?action=edit-job&job_id=' . $job_id . '">Edit job</a></li>'
+             . '</ul>';
+    }
+    return '<ul class="dropdown-menu"><li>'
+         . '<span class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right" title="' . $tooltip . '">'
+         . '<a class="dropdown-item disabled" href="?action=cancel-job&job_id=' . $job_id . '" aria-disabled="true">Cancel job</a></span>'
+         . '<span class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right" title="' . $tooltip . '">'
+         . '<a class="dropdown-item disabled" href="?action=edit-job&job_id=' . $job_id . '" aria-disabled="true">Edit job</a></span>'
+         . '</li></ul>';
+}

--- a/view/job_history.tpl.php
+++ b/view/job_history.tpl.php
@@ -276,28 +276,16 @@ EOF;
                    . ' data-bs-toggle="dropdown" aria-expanded="false">'
                    . '<span class="visually-hidden">Toggle Dropdown</span></button>';
 
-        if (\client\utils\jwt\JwtAuthentication::is_supported() && !empty(array_intersect($job['job_state'], $active_states))) {
-            $contents .= '<ul class="dropdown-menu">'
-                       . '<li><a class="dropdown-item" href="?action=cancel-job&job_id=' . $job['job_id'] . '">Cancel job</a></li>'
-                       . '<li><a class="dropdown-item" href="?action=edit-job&job_id=' . $job['job_id'] . '">Edit job</a></li>'
-                       . '</ul>';
-        } elseif (!\client\utils\jwt\JwtAuthentication::is_supported()) {
-            $tooltip = 'This feature is not supported by the current configuration.';
-            $contents .= '<ul class="dropdown-menu"><li>'
-                       . '<span class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right" title="' . $tooltip . '">'
-                       . '<a class="dropdown-item disabled" href="?action=cancel-job&job_id=' . $job['job_id'] . '" aria-disabled="true">Cancel job</a></span>'
-                       . '<span class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right" title="' . $tooltip . '">'
-                       . '<a class="dropdown-item disabled" href="?action=edit-job&job_id=' . $job['job_id'] . '" aria-disabled="true">Edit job</a></span>'
-                       . '</li></ul>';
-        } else {
-            $tooltip = 'Job is no longer active.';
-            $contents .= '<ul class="dropdown-menu"><li>'
-                       . '<span class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right" title="' . $tooltip . '">'
-                       . '<a class="dropdown-item disabled" href="?action=cancel-job&job_id=' . $job['job_id'] . '" aria-disabled="true">Cancel job</a></span>'
-                       . '<span class="dropdown-item" data-bs-toggle="tooltip" data-bs-placement="right" title="' . $tooltip . '">'
-                       . '<a class="dropdown-item disabled" href="?action=edit-job&job_id=' . $job['job_id'] . '" aria-disabled="true">Edit job</a></span>'
-                       . '</li></ul>';
-        }
+        // $job['user_name'] may be empty if the user does not exist on slurmrestd host —
+        // in this case the configuration does not allow to determine the user name.
+        if (\client\utils\jwt\JwtAuthentication::is_supported() && !empty(array_intersect($job['job_state'], $active_states)) && !empty($job['user_name']) && (\auth\current_user_is_admin() || $job['user_name'] === $_SESSION['USER']))
+            $contents .= render_job_action_dropdown($job['job_id'], FALSE);
+        elseif (!\client\utils\jwt\JwtAuthentication::is_supported() || empty($job['user_name']))
+            $contents .= render_job_action_dropdown($job['job_id'], TRUE, 'This feature is not supported by the current configuration.');
+        elseif (empty(array_intersect($job['job_state'], $active_states)))
+            $contents .= render_job_action_dropdown($job['job_id'], TRUE, 'Job is no longer active.');
+        else
+            $contents .= render_job_action_dropdown($job['job_id'], TRUE, 'You are not authorized to cancel or edit this job.');
 
         $contents .= '</div></td>';
         $contents .= '</tr>';

--- a/view/slurm-queue.tpl.php
+++ b/view/slurm-queue.tpl.php
@@ -154,6 +154,8 @@ EOF;
  * @return string Rendered HTML
  */
 function get_slurm_queue_table(array $jobs) : string {
+    $active_states = ['PENDING', 'RUNNING', 'COMPLETING', 'CONFIGURING', 'SUSPENDED', 'REQUEUED'];
+
     $contents = <<<EOF
 <div class="table-responsive tableFixHead">
     <table class="table" id="jobtable-table">
@@ -206,42 +208,16 @@ EOF;
             <span class="visually-hidden">Toggle Dropdown</span>
         </button>
 EOF;
-        if( \client\utils\jwt\JwtAuthentication::is_supported() ){
-            $contents .= <<<EOF
-        <ul class="dropdown-menu">
-            <li><a class="dropdown-item" href="?action=cancel-job&job_id={$job['job_id']}">Cancel job</a></li>
-            <li><a class="dropdown-item" href="?action=edit-job&job_id={$job['job_id']}">Edit job</a></li>
-        </ul>
-EOF;
-        }
-        else {
-            $contents .= <<<EOF
-        <ul class="dropdown-menu">
-            <li>
-                <span class="dropdown-item" 
-                      data-bs-toggle="tooltip" 
-                      data-bs-placement="right"
-                      title="This feature is not supported by the current configuration.">
-                      <a class="dropdown-item disabled" 
-                         href="?action=cancel-job&job_id={$job['job_id']}"
-                         aria-disabled="true">
-                        Cancel job
-                      </a>
-                </span>
-                <span class="dropdown-item" 
-                      data-bs-toggle="tooltip" 
-                      data-bs-placement="right"
-                      title="This feature is not supported by the current configuration.">
-                      <a class="dropdown-item disabled" 
-                         href="?action=edit-job&job_id={$job['job_id']}"
-                         aria-disabled="true">
-                        Edit job
-                      </a>
-                </span>
-            </li>
-        </ul>
-EOF;
-        }
+        // $job['user_name'] may be empty if the user does not exist on slurmrestd host —
+        // in this case the configuration does not allow to determine the user name.
+        if (\client\utils\jwt\JwtAuthentication::is_supported() && !empty(array_intersect($job['job_state'], $active_states)) && !empty($job['user_name']) && (\auth\current_user_is_admin() || $job['user_name'] === $_SESSION['USER']))
+            $contents .= render_job_action_dropdown($job['job_id'], FALSE);
+        elseif (!\client\utils\jwt\JwtAuthentication::is_supported() || empty($job['user_name']))
+            $contents .= render_job_action_dropdown($job['job_id'], TRUE, 'This feature is not supported by the current configuration.');
+        elseif (empty(array_intersect($job['job_state'], $active_states)))
+            $contents .= render_job_action_dropdown($job['job_id'], TRUE, 'Job is no longer active.');
+        else
+            $contents .= render_job_action_dropdown($job['job_id'], TRUE, 'You are not authorized to cancel or edit this job.');
 
         $contents .= <<<EOF
     </div>
@@ -264,6 +240,7 @@ EOF;
  * @return string Rendered HTML
  */
 function get_slurm_queue_compact(array $jobs) : string {
+    $active_states = ['PENDING', 'RUNNING', 'COMPLETING', 'CONFIGURING', 'SUSPENDED', 'REQUEUED'];
 
     $contents = <<<EOF
 <div id="jobtable-compact" class="table-responsive tableFixHead">
@@ -310,42 +287,16 @@ EOF;
             <span class="visually-hidden">Toggle Dropdown</span>
         </button>
 EOF;
-        if( \client\utils\jwt\JwtAuthentication::is_supported() ){
-            $contents .= <<<EOF
-        <ul class="dropdown-menu">
-            <li><a class="dropdown-item" href="?action=cancel-job&job_id={$job['job_id']}">Cancel job</a></li>
-            <li><a class="dropdown-item" href="?action=edit-job&job_id={$job['job_id']}">Edit job</a></li>
-        </ul>
-EOF;
-        }
-        else {
-            $contents .= <<<EOF
-        <ul class="dropdown-menu">
-            <li>
-                <span class="dropdown-item" 
-                      data-bs-toggle="tooltip" 
-                      data-bs-placement="right"
-                      title="This feature is not supported by the current configuration.">
-                      <a class="dropdown-item disabled" 
-                         href="?action=cancel-job&job_id={$job['job_id']}"
-                         aria-disabled="true">
-                        Cancel job
-                      </a>
-                </span>
-                <span class="dropdown-item" 
-                      data-bs-toggle="tooltip" 
-                      data-bs-placement="right"
-                      title="This feature is not supported by the current configuration.">
-                      <a class="dropdown-item disabled" 
-                         href="?action=edit-job&job_id={$job['job_id']}"
-                         aria-disabled="true">
-                        Edit job
-                      </a>
-                </span>
-            </li>
-        </ul>
-EOF;
-        }
+        // $job['user_name'] may be empty if the user does not exist on slurmrestd host —
+        // in this case the configuration does not allow to determine the user name.
+        if (\client\utils\jwt\JwtAuthentication::is_supported() && !empty(array_intersect($job['job_state'], $active_states)) && !empty($job['user_name']) && (\auth\current_user_is_admin() || $job['user_name'] === $_SESSION['USER']))
+            $contents .= render_job_action_dropdown($job['job_id'], FALSE);
+        elseif (!\client\utils\jwt\JwtAuthentication::is_supported() || empty($job['user_name']))
+            $contents .= render_job_action_dropdown($job['job_id'], TRUE, 'This feature is not supported by the current configuration.');
+        elseif (empty(array_intersect($job['job_state'], $active_states)))
+            $contents .= render_job_action_dropdown($job['job_id'], TRUE, 'Job is no longer active.');
+        else
+            $contents .= render_job_action_dropdown($job['job_id'], TRUE, 'You are not authorized to cancel or edit this job.');
 
         $contents .= <<<EOF
     </div>


### PR DESCRIPTION
- Disable "edit job" and "cancel job" if
    - the job is already in a finished state
    - the user is not allowed to use the button (because he is no admin and it is not his job)
    - the current configuration does not enable to do these actions (because either JWT is not enabled or the user name could not be determined).
- Handle the case where the user name is not set in a slurmrestd response of endpoint /jobs or /job/id. This can happen if the respective user does not exist on the slurmrestd host.